### PR TITLE
Add an Advanced tab

### DIFF
--- a/OpenIPC_Config.Tests/Services/GitHubServiceTests.cs
+++ b/OpenIPC_Config.Tests/Services/GitHubServiceTests.cs
@@ -7,6 +7,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Moq.Protected;
 using OpenIPC_Config.Services;
+using Serilog;
 using Xunit;
 using Assert = NUnit.Framework.Assert;
 
@@ -16,13 +17,16 @@ public class GitHubServiceTests
     private readonly HttpClient _httpClient;
     private readonly IMemoryCache _memoryCache;
     private readonly GitHubService _gitHubService;
+    private readonly ILogger _logger;
+    
 
     public GitHubServiceTests()
     {
         _httpMessageHandlerMock = new Mock<HttpMessageHandler>();
         _httpClient = new HttpClient(_httpMessageHandlerMock.Object);
         _memoryCache = new MemoryCache(new MemoryCacheOptions());
-        _gitHubService = new GitHubService(_memoryCache, _httpClient);
+        _logger = new LoggerConfiguration().WriteTo.Console().CreateLogger();
+        _gitHubService = new GitHubService(_memoryCache, _httpClient, _logger);
     }
 
     [Fact]

--- a/OpenIPC_Config/App.axaml.cs
+++ b/OpenIPC_Config/App.axaml.cs
@@ -362,6 +362,7 @@ public class App : Application
         services.AddSingleton<WfbTabViewModel>();
         services.AddSingleton<FirmwareTabViewModel>();
         services.AddSingleton<PresetsTabViewModel>();
+        services.AddSingleton<AdvancedTabViewModel>();
     }
 
     private static void RegisterViews(IServiceCollection services)
@@ -380,6 +381,7 @@ public class App : Application
         services.AddTransient<FirmwareTabView>();
         services.AddTransient<WfbTabView>();
         services.AddTransient<PresetsTabView>();
+        services.AddTransient<AdvancedTabView>();
     }
 
     private JObject createDefaultAppSettings()

--- a/OpenIPC_Config/Assets/Icons/iconair_advanced_dark.svg
+++ b/OpenIPC_Config/Assets/Icons/iconair_advanced_dark.svg
@@ -1,0 +1,8 @@
+<svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <!-- Wrench icon for advanced tools/settings -->
+    <path d="M15.84 13.5l-6.72-6.72c0.48-1.12 0.4-2.48-0.48-3.44-0.96-0.96-2.32-1.04-3.44-0.48L8.16 5.84 5.84 8.16 2.88 5.2c-0.56 1.12-0.48 2.48 0.48 3.44 0.96 0.88 2.32 0.96 3.44 0.48l6.72 6.72c0.32 0.32 0.8 0.32 1.12 0l1.2-1.2c0.32-0.32 0.32-0.8 0-1.12z" fill="#252525"/>
+
+    <!-- Code brackets to indicate advanced functionality -->
+    <path d="M5.5 2L3 4.5L5.5 7" stroke="#252525" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M10.5 2L13 4.5L10.5 7" stroke="#252525" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/OpenIPC_Config/Assets/Icons/iconair_advanced_light.svg
+++ b/OpenIPC_Config/Assets/Icons/iconair_advanced_light.svg
@@ -1,0 +1,8 @@
+<svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <!-- Wrench icon for advanced tools/settings -->
+    <path d="M15.84 13.5l-6.72-6.72c0.48-1.12 0.4-2.48-0.48-3.44-0.96-0.96-2.32-1.04-3.44-0.48L8.16 5.84 5.84 8.16 2.88 5.2c-0.56 1.12-0.48 2.48 0.48 3.44 0.96 0.88 2.32 0.96 3.44 0.48l6.72 6.72c0.32 0.32 0.8 0.32 1.12 0l1.2-1.2c0.32-0.32 0.32-0.8 0-1.12z" fill="#D9D9D9"/>
+
+    <!-- Code brackets to indicate advanced functionality -->
+    <path d="M5.5 2L3 4.5L5.5 7" stroke="#D9D9D9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M10.5 2L13 4.5L10.5 7" stroke="#D9D9D9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/OpenIPC_Config/Models/DeviceCommands.cs
+++ b/OpenIPC_Config/Models/DeviceCommands.cs
@@ -73,7 +73,7 @@ public static class DeviceCommands
     public static string GetNetworkCardType = "lsusb";
 
     // Improved command to add alink_drone if not present
-    public const string AddAlinkDroneToRcLocal = "grep -q \"alink_drone\" /etc/rc.local || sed -i '/^exit 0/i # Start alink drone service\\nalink_drone \\&\\n' /etc/rc.local";
+    public const string AddAlinkDroneToRcLocal = "grep -q \"alink_drone\" /etc/rc.local || sed -i '/^exit 0/i # Start alink drone service\\n/usr/bin/alink_drone --ip 10.5.0.10 --port 9999 \\&\\n' /etc/rc.local";
 
     // Improved command to remove both the service line and its comment
     public const string RemoveAlinkDroneFromRcLocal = "sed -i '/# Start alink drone service/d; /alink_drone/d; /^$/d' /etc/rc.local";

--- a/OpenIPC_Config/OpenIPC_Config.csproj
+++ b/OpenIPC_Config/OpenIPC_Config.csproj
@@ -93,6 +93,10 @@
             <DependentUpon>Resources.es.resx</DependentUpon>
         </Compile>
 
+        <Compile Update="ViewModels\StatusBarViewModel.cs">
+          <DependentUpon>PresetsTabViewModel.cs</DependentUpon>
+        </Compile>
+
         <!--        <Compile Update="Views\PreferencesTabView.axaml.cs">-->
         <!--          <DependentUpon>PreferencesTabView.axaml</DependentUpon>-->
         <!--        </Compile>-->

--- a/OpenIPC_Config/Services/EventSubscriptionService.cs
+++ b/OpenIPC_Config/Services/EventSubscriptionService.cs
@@ -19,12 +19,13 @@ public class EventSubscriptionService : IEventSubscriptionService
     public EventSubscriptionService(IEventAggregator eventAggregator, ILogger logger)
     {
         _eventAggregator = eventAggregator ?? throw new ArgumentNullException(nameof(eventAggregator));
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _logger = logger?.ForContext(GetType()) ?? 
+                  throw new ArgumentNullException(nameof(logger));
     }
-
+    
     public void Subscribe<TEvent, TPayload>(Action<TPayload> action) where TEvent : PubSubEvent<TPayload>, new()
     {
-        _eventAggregator.GetEvent<TEvent>().Subscribe(action);
+        _eventAggregator.GetEvent<TEvent>().Subscribe(action, ThreadOption.UIThread);
         _logger.Verbose($"Subscribed to event {typeof(TEvent).Name}");
     }
 

--- a/OpenIPC_Config/Services/MessageBoxService.cs
+++ b/OpenIPC_Config/Services/MessageBoxService.cs
@@ -1,13 +1,31 @@
 using System.Threading.Tasks;
+using Avalonia.Controls;
 using MsBox.Avalonia;
+using MsBox.Avalonia.Dto;
+using MsBox.Avalonia.Enums;
 
 namespace OpenIPC_Config.Services;
 
 public class MessageBoxService : IMessageBoxService
 {
+    
     public async Task ShowMessageBox(string title, string message)
     {
-        var msgBox = MessageBoxManager.GetMessageBoxStandard(title, message);
-        await msgBox.ShowAsync();
+        var msgBox = MessageBoxManager.GetMessageBoxStandard(
+            new MessageBoxStandardParams 
+            {
+                ContentTitle = title,
+                ContentMessage = message,
+                ButtonDefinitions = ButtonEnum.Ok,
+                WindowStartupLocation = WindowStartupLocation.CenterScreen,
+                Topmost = true
+            }
+        );
+
+        // Show the message box and ensure it's activated and focused
+        var result = await msgBox.ShowAsync();
+        
+        // Optional: You can do something with the result if needed
+        // For example, log which button was pressed or perform an action
     }
 }

--- a/OpenIPC_Config/Services/YamlConfigService.cs
+++ b/OpenIPC_Config/Services/YamlConfigService.cs
@@ -12,7 +12,8 @@ public class YamlConfigService : IYamlConfigService
 
     public YamlConfigService(ILogger logger)
     {
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _logger = logger?.ForContext(GetType()) ?? 
+                  throw new ArgumentNullException(nameof(logger));
     }
 
     public void ParseYaml(string content, Dictionary<string, string> yamlConfig)

--- a/OpenIPC_Config/ViewModels/AdvancedTabViewModel.cs
+++ b/OpenIPC_Config/ViewModels/AdvancedTabViewModel.cs
@@ -1,0 +1,939 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using OpenIPC_Config.Events;
+using OpenIPC_Config.Models;
+using OpenIPC_Config.Services;
+using Serilog;
+
+namespace OpenIPC_Config.ViewModels;
+
+public partial class AdvancedTabViewModel : ViewModelBase
+{
+    #region Fields
+
+    private bool _isAdaptiveLinkInstalling;
+    private string _adaptiveLinkInstallStatus = "";
+    private int _adaptiveLinkInstallProgress;
+    private string _customScriptContent = "";
+    private string _scriptFilename = "";
+    private string _selectedScriptType;
+    private readonly IYamlConfigService _yamlConfigService;
+    private bool _isAdaptiveLinkInstalled;
+    private bool _isAdaptiveLinkRunning;
+    private string _adaptiveLinkVersion = "Unknown";
+
+    #endregion
+
+    #region Properties
+
+    [ObservableProperty] private bool _canConnect;
+
+    public bool IsAlinkDroneDisabled => !IsAlinkDroneEnabled;
+
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(IsAlinkDroneDisabled))]
+    private bool _isAlinkDroneEnabled;
+
+    public bool InstalledButNotRunning => IsAdaptiveLinkInstalled && !IsAdaptiveLinkRunning;
+
+    public bool NotInstalled => !IsAdaptiveLinkInstalled;
+
+    public bool CanInstall
+    {
+        get => !IsAdaptiveLinkInstalling && DeviceConfig.Instance.CanConnect;
+    }
+
+    public bool IsAdaptiveLinkInstalling
+    {
+        get => _isAdaptiveLinkInstalling;
+        set => SetProperty(ref _isAdaptiveLinkInstalling, value);
+    }
+
+    public string AdaptiveLinkInstallStatus
+    {
+        get => _adaptiveLinkInstallStatus;
+        set => SetProperty(ref _adaptiveLinkInstallStatus, value);
+    }
+
+    public int AdaptiveLinkInstallProgress
+    {
+        get => _adaptiveLinkInstallProgress;
+        set => SetProperty(ref _adaptiveLinkInstallProgress, value);
+    }
+
+    public bool IsAdaptiveLinkInstalled
+    {
+        get => _isAdaptiveLinkInstalled;
+        set => SetProperty(ref _isAdaptiveLinkInstalled, value);
+    }
+
+    public bool IsAdaptiveLinkRunning
+    {
+        get => _isAdaptiveLinkRunning;
+        set => SetProperty(ref _isAdaptiveLinkRunning, value);
+    }
+
+    public string AdaptiveLinkVersion
+    {
+        get => _adaptiveLinkVersion;
+        set => SetProperty(ref _adaptiveLinkVersion, value);
+    }
+
+    #endregion
+
+    #region Commands
+
+    public IAsyncRelayCommand InstallAdaptiveLinkCommand { get; }
+    public IAsyncRelayCommand CheckAdaptiveLinkStatusCommand { get; }
+    public IAsyncRelayCommand GenerateSystemReportCommand { get; }
+    public IAsyncRelayCommand ViewSystemLogsCommand { get; }
+    public IAsyncRelayCommand NetworkDiagnosticsCommand { get; }
+
+    // Command property for toggling alink_drone
+    public IAsyncRelayCommand ToggleAlinkDroneCommand { get; set; }
+
+    #endregion
+
+    public AdvancedTabViewModel(
+        ILogger logger,
+        ISshClientService sshClientService,
+        IEventSubscriptionService eventSubscriptionService,
+        IYamlConfigService yamlConfigService)
+        : base(logger, sshClientService, eventSubscriptionService)
+    {
+        SubscribeToEvents();
+
+        _yamlConfigService = yamlConfigService ?? throw new ArgumentNullException(nameof(yamlConfigService));
+
+        // Initialize commands
+        InstallAdaptiveLinkCommand = new AsyncRelayCommand(InstallAdaptiveLinkOfflineAsync);
+        CheckAdaptiveLinkStatusCommand = new AsyncRelayCommand(CheckAdaptiveLinkStatusAsync);
+        GenerateSystemReportCommand = new AsyncRelayCommand(GenerateSystemReportAsync);
+        ViewSystemLogsCommand = new AsyncRelayCommand(ViewSystemLogsAsync);
+        NetworkDiagnosticsCommand = new AsyncRelayCommand(NetworkDiagnosticsAsync);
+        ToggleAlinkDroneCommand = new AsyncRelayCommand(async () => await ToggleAlinkDroneAsync());
+    }
+
+    #region Adaptive Link Methods
+
+    // Method to toggle the alink_drone status
+    private async Task ToggleAlinkDroneAsync()
+    {
+        if (_isUpdatingAlinkDroneStatus)
+            return;
+
+        _isUpdatingAlinkDroneStatus = true;
+        try
+        {
+            if (!DeviceConfig.Instance.CanConnect)
+            {
+                UpdateUIMessage("Device not connected. Cannot toggle Adaptive Link status.");
+                return;
+            }
+
+            string command = IsAlinkDroneEnabled
+                ? DeviceCommands.RemoveAlinkDroneFromRcLocal
+                : DeviceCommands.AddAlinkDroneToRcLocal;
+
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60)); // 60 seconds timeout
+            var result =
+                await SshClientService.ExecuteCommandWithResponseAsync(DeviceConfig.Instance, command, cts.Token);
+
+            // Refresh status to confirm changes
+            await CheckAlinkDroneStatusAsync();
+
+            UpdateUIMessage(IsAlinkDroneEnabled
+                ? "Adaptive Link enabled on boot."
+                : "Adaptive Link disabled on boot.");
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "Error toggling Adaptive Link status");
+            UpdateUIMessage($"Error toggling Adaptive Link status: {ex.Message}");
+        }
+        finally
+        {
+            _isUpdatingAlinkDroneStatus = false;
+        }
+    }
+
+    private bool _isUpdatingAlinkDroneStatus = false;
+
+    partial void OnIsAlinkDroneEnabledChanged(bool value)
+    {
+        if (CanConnect && !_isUpdatingAlinkDroneStatus)
+        {
+            _ = ApplyAlinkDroneStatus(value);
+        }
+    }
+
+    // Method to check the current status
+
+    private async Task CheckAlinkDroneStatusAsync()
+    {
+        if (!DeviceConfig.Instance.CanConnect || _isUpdatingAlinkDroneStatus)
+            return;
+
+        _isUpdatingAlinkDroneStatus = true;
+        try
+        {
+            var cts = new CancellationTokenSource(10000); // 10 seconds timeout
+            var cmdResult = await SshClientService.ExecuteCommandWithResponseAsync(
+                DeviceConfig.Instance,
+                DeviceCommands.IsAlinkDroneEnabled,
+                cts.Token);
+
+            bool newStatus = cmdResult?.Result?.Trim().Equals("true", StringComparison.OrdinalIgnoreCase) ?? false;
+
+            // Only update if status actually changed to avoid recursive property change notifications
+            if (IsAlinkDroneEnabled != newStatus)
+            {
+                IsAlinkDroneEnabled = newStatus;
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "Error checking Adaptive Link status");
+        }
+        finally
+        {
+            _isUpdatingAlinkDroneStatus = false;
+        }
+    }
+
+
+    private async Task ApplyAlinkDroneStatus(bool enable)
+    {
+        _isUpdatingAlinkDroneStatus = true;
+        try
+        {
+            if (enable)
+            {
+                await SshClientService.ExecuteCommandAsync(DeviceConfig.Instance,
+                    DeviceCommands.AddAlinkDroneToRcLocal);
+            }
+            else
+            {
+                await SshClientService.ExecuteCommandAsync(DeviceConfig.Instance,
+                    DeviceCommands.RemoveAlinkDroneFromRcLocal);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "Error setting Alink Drone status");
+        }
+        finally
+        {
+            _isUpdatingAlinkDroneStatus = false;
+        }
+    }
+
+    private async Task InstallAdaptiveLinkOfflineAsync()
+    {
+        try
+        {
+            var deviceConfig = DeviceConfig.Instance;
+            if (!deviceConfig.CanConnect)
+            {
+                UpdateUIMessage("Device not connected. Cannot install Adaptive Link.");
+                return;
+            }
+
+            // Set UI state to installing
+            IsAdaptiveLinkInstalling = true;
+            AdaptiveLinkInstallProgress = 0;
+            AdaptiveLinkInstallStatus = "Starting installation...";
+
+            Logger.Information("Starting Adaptive Link installation via local PC download");
+
+            // Create temporary directory
+            string tempPath = Path.Combine(Path.GetTempPath(), "AdaptiveLinkTemp_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempPath);
+            Logger.Information("Created temporary directory: {TempPath}", tempPath);
+
+            try
+            {
+                // Define GitHub repository info
+                const string repoOwner = "OpenIPC";
+                const string repoName = "adaptive-link";
+
+                // Step 1: Download files from GitHub to local temp directory
+                AdaptiveLinkInstallStatus = "Downloading files from GitHub...";
+                AdaptiveLinkInstallProgress = 10;
+
+                // Required files list
+                var requiredFiles = new Dictionary<string, string>
+                {
+                    { "alink_drone", "/usr/bin/alink_drone" },
+                    { "txprofiles.conf", "/etc/txprofiles.conf" },
+                    { "alink.conf", "/etc/alink.conf" }
+                };
+
+                // Download each file from the latest release
+                using (var httpClient = new HttpClient())
+                {
+                    // GitHub API requires a user agent
+                    httpClient.DefaultRequestHeaders.Add("User-Agent", "AdaptiveLinkInstaller");
+
+                    // Get the latest release info
+                    AdaptiveLinkInstallStatus = "Getting latest release information...";
+                    var releasesJson =
+                        await httpClient.GetStringAsync(
+                            $"https://api.github.com/repos/{repoOwner}/{repoName}/releases");
+
+                    // Parse JSON to get download URLs (using System.Text.Json)
+                    using (JsonDocument doc = JsonDocument.Parse(releasesJson))
+                    {
+                        // Get the first (latest) release
+                        var latestRelease = doc.RootElement[0];
+                        var assets = latestRelease.GetProperty("assets");
+
+                        foreach (var file in requiredFiles.Keys)
+                        {
+                            AdaptiveLinkInstallStatus = $"Downloading {file}...";
+
+                            // Find the asset with matching name
+                            string downloadUrl = null;
+                            foreach (var asset in assets.EnumerateArray())
+                            {
+                                var name = asset.GetProperty("name").GetString();
+                                if (name == file)
+                                {
+                                    downloadUrl = asset.GetProperty("browser_download_url").GetString();
+                                    break;
+                                }
+                            }
+
+                            if (string.IsNullOrEmpty(downloadUrl))
+                            {
+                                throw new Exception($"File {file} not found in the latest release");
+                            }
+
+                            // Download the file
+                            var fileBytes = await httpClient.GetByteArrayAsync(downloadUrl);
+                            await File.WriteAllBytesAsync(Path.Combine(tempPath, file), fileBytes);
+                            Logger.Information("Downloaded {File} to {Path}", file, Path.Combine(tempPath, file));
+                        }
+                    }
+                }
+
+                // Step 2: Upload files from temp directory to device
+                AdaptiveLinkInstallStatus = "Copying files to device...";
+                AdaptiveLinkInstallProgress = 50;
+
+                foreach (var file in requiredFiles)
+                {
+                    var localFilePath = Path.Combine(tempPath, file.Key);
+                    var remoteFilePath = file.Value;
+
+                    AdaptiveLinkInstallStatus = $"Copying {file.Key} to device...";
+                    await SshClientService.UploadFileAsync(
+                        deviceConfig,
+                        localFilePath,
+                        remoteFilePath
+                    );
+                }
+
+                // Step 3: Make the drone file executable
+                AdaptiveLinkInstallStatus = "Making alink_drone executable...";
+                AdaptiveLinkInstallProgress = 70;
+
+                var cts = new CancellationTokenSource(10000); // 10 seconds
+                var cancellationToken = cts.Token;
+                var chmodResult = await SshClientService.ExecuteCommandWithResponseAsync(deviceConfig,
+                    "chmod +x /usr/bin/alink_drone", cancellationToken);
+
+                if (chmodResult?.ExitStatus != 0)
+                {
+                    AdaptiveLinkInstallStatus = $"Chmod failed: {chmodResult?.Error ?? "Unknown error"}";
+                    throw new Exception("Failed to make alink_drone executable");
+                }
+
+                // Step 4: Configure required settings
+                AdaptiveLinkInstallStatus = "Configuring Adaptive Link...";
+                AdaptiveLinkInstallProgress = 80;
+
+                // Run necessary configuration commands
+                var configCommands = new List<string>
+                {
+                    "cli -s .video0.qpDelta -12",
+                    "cli -s .fpv.enabled true",
+                    "cli -s .fpv.noiseLevel 0",
+                    "sed -i 's/tunnel=.*/tunnel=true/' /etc/datalink.conf",
+                    "sed -i -e '$i \\/usr/bin/alink_drone --ip 10.5.0.10 --port 9999 &' /etc/rc.local"
+                };
+
+                foreach (var cmd in configCommands)
+                {
+                    cts = new CancellationTokenSource(10000);
+                    cancellationToken = cts.Token;
+                    var cmdResult = await SshClientService.ExecuteCommandWithResponseAsync(
+                        deviceConfig, cmd, cancellationToken);
+
+                    if (cmdResult?.ExitStatus != 0)
+                    {
+                        Logger.Warning("Command {Cmd} finished with exit code {Code}",
+                            cmd, cmdResult?.ExitStatus);
+                        // Continue despite errors for flexibility
+                    }
+                }
+
+                // Step 5: Prepare for reboot
+                AdaptiveLinkInstallStatus = "Installation complete. Preparing to reboot the device...";
+                AdaptiveLinkInstallProgress = 90;
+
+                // Let the user know before rebooting
+                UpdateUIMessage("Adaptive Link installation successful. Device will reboot in 5 seconds.");
+
+                // Wait briefly to ensure the message is seen
+                await Task.Delay(5000);
+
+                // Step 6: Reboot the device
+                AdaptiveLinkInstallStatus = "Rebooting device...";
+                AdaptiveLinkInstallProgress = 100;
+                await SshClientService.ExecuteCommandAsync(deviceConfig, "reboot");
+
+                // Reset UI state after a brief delay (device will disconnect due to reboot)
+                await Task.Delay(3000);
+                IsAdaptiveLinkInstalling = false;
+
+                // Inform the user
+                UpdateUIMessage("Device is rebooting. Please reconnect after the reboot completes.");
+            }
+            finally
+            {
+                // Clean up temp directory when done
+                try
+                {
+                    if (Directory.Exists(tempPath))
+                    {
+                        Directory.Delete(tempPath, true);
+                        Logger.Information("Cleaned up temporary directory");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Logger.Warning(ex, "Failed to clean up temporary directory: {ErrorMessage}", ex.Message);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "Failed to install Adaptive Link");
+            AdaptiveLinkInstallStatus = $"Installation failed: {ex.Message}";
+            UpdateUIMessage($"Error installing Adaptive Link: {ex.Message}");
+
+            // Reset UI state
+            IsAdaptiveLinkInstalling = false;
+        }
+    }
+
+
+// Helper method to extract files to the temp directory - implement this based on how you store the files
+    private void ExtractFilesToTempDirectory(string tempPath, List<string> fileNames)
+    {
+        // Implementation depends on how you're storing these files in your application
+        // Options include:
+        // 1. Embedded resources
+        // 2. Files included in your application folder
+        // 3. Files from a zip package
+
+        // Example for embedded resources:
+        foreach (var fileName in fileNames)
+        {
+            var resourceName = $"YourNamespace.Resources.{fileName}";
+            using (var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(resourceName))
+            {
+                if (stream == null)
+                {
+                    throw new FileNotFoundException($"Required resource not found: {resourceName}");
+                }
+
+                using (var fileStream = new FileStream(Path.Combine(tempPath, fileName), FileMode.Create))
+                {
+                    stream.CopyTo(fileStream);
+                }
+            }
+        }
+    }
+
+    private async Task CheckAdaptiveLinkStatusAsync()
+    {
+        try
+        {
+            var deviceConfig = DeviceConfig.Instance;
+            if (!deviceConfig.CanConnect)
+            {
+                UpdateUIMessage("Device not connected. Cannot check Adaptive Link status.");
+                return;
+            }
+
+            UpdateUIMessage("Checking Adaptive Link status...");
+
+            // Reset status properties
+            IsAdaptiveLinkInstalled = false;
+            IsAdaptiveLinkRunning = false;
+            AdaptiveLinkVersion = "Unknown";
+
+            // Check if the alink_drone executable exists
+            string checkCommand = "[ -f /usr/bin/alink_drone ] && echo 'INSTALLED' || echo 'NOT_INSTALLED'";
+            var cts = new CancellationTokenSource(10000); // 10 seconds
+            var cancellationToken = cts.Token;
+
+            var checkResult =
+                await SshClientService.ExecuteCommandWithResponseAsync(deviceConfig, checkCommand, cancellationToken);
+            string statusOutput = checkResult?.Result?.Trim() ?? "Failed to check status";
+
+            if (statusOutput != "INSTALLED")
+            {
+                UpdateUIMessage("Adaptive Link is not installed on this device.");
+                return;
+            }
+
+            // File exists, so Adaptive Link is installed
+            IsAdaptiveLinkInstalled = true;
+
+            // Check if it's running
+            cts = new CancellationTokenSource(10000);
+            cancellationToken = cts.Token;
+            var runningCheck = await SshClientService.ExecuteCommandWithResponseAsync(deviceConfig,
+                "ps | grep alink_drone | grep -v grep | wc -l", cancellationToken);
+
+            // If count > 0, it's running
+            int processCount = int.TryParse(runningCheck?.Result?.Trim(), out var count) ? count : 0;
+            IsAdaptiveLinkRunning = processCount > 0;
+
+            // Check configuration file
+            cts = new CancellationTokenSource(10000);
+            cancellationToken = cts.Token;
+            var configResult = await SshClientService.ExecuteCommandWithResponseAsync(deviceConfig,
+                "cat /etc/alink.conf 2>/dev/null || echo 'Configuration not found'", cancellationToken);
+
+            string configOutput = configResult?.Result ?? "No configuration available";
+
+            StringBuilder statusInfo = new StringBuilder();
+            statusInfo.AppendLine(
+                $"Adaptive Link is installed and {(IsAdaptiveLinkRunning ? "running" : "not running")}.");
+
+
+            statusInfo.AppendLine();
+            statusInfo.AppendLine("Configuration:");
+            statusInfo.AppendLine(configOutput);
+
+            UpdateUIMessage(statusInfo.ToString());
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "Failed to check Adaptive Link status");
+            UpdateUIMessage($"Error checking Adaptive Link status: {ex.Message}");
+        }
+    }
+
+    #endregion
+
+    #region Initialization Methods
+
+    private void SubscribeToEvents()
+    {
+        EventSubscriptionService.Subscribe<AppMessageEvent, AppMessage>(OnAppMessage);
+        // Subscribe to alink drone status updates
+        EventSubscriptionService.Subscribe<AlinkDroneStatusEvent, bool>(status => IsAlinkDroneEnabled = status);
+    }
+
+    #endregion
+
+    #region Debug Tool Methods
+
+    private async Task GenerateSystemReportAsync()
+    {
+        try
+        {
+            var deviceConfig = DeviceConfig.Instance;
+            if (!deviceConfig.CanConnect)
+            {
+                UpdateUIMessage("Device not connected. Cannot generate system report.");
+                return;
+            }
+
+            UpdateUIMessage("Generating system report...");
+
+            // System commands to gather information
+            var systemCommands = new List<(string Section, string Command)>
+            {
+                ("System Information", "uname -a"),
+                ("CPU Info", "cat /proc/cpuinfo | grep -i 'model name\\|processor'"),
+                ("Memory Info", "free -h"),
+                ("Disk Usage", "df -h"),
+                ("Network Interfaces", "ip addr"),
+                ("Loaded Modules", "lsmod"),
+                ("Active Services", "systemctl list-units --type=service --state=running")
+            };
+
+            // Configuration files to include
+            var configFiles = new List<string>
+            {
+                "/etc/os-release",
+                "/etc/majestic.yaml",
+                "/etc/wfb.yaml",
+                "/etc/wfb.conf",
+                "/etc/telemetry.conf",
+                "/etc/alink.conf",
+                "/etc/vtxmenu.ini",
+                "/etc/txprofiles.conf",
+                "/etc/datalink.conf"
+                // Add new files here as needed
+            };
+
+            // Build the command string
+            var commandBuilder = new StringBuilder();
+
+            // Add system commands
+            foreach (var (section, command) in systemCommands)
+            {
+                commandBuilder.Append($"echo '=== {section} ===' && {command} && ");
+            }
+
+            // Add configuration files section header
+            commandBuilder.Append("echo '=== OpenIPC Configurations ===' && ");
+
+            // Add each configuration file
+            foreach (var file in configFiles)
+            {
+                string filename = Path.GetFileName(file);
+                commandBuilder.Append($"echo '--- {file} ---' && ");
+                commandBuilder.Append($"cat {file} 2>/dev/null || echo 'File not found' && ");
+            }
+
+            // Remove the trailing " && "
+            string reportCommands = commandBuilder.ToString();
+            if (reportCommands.EndsWith(" && "))
+            {
+                reportCommands = reportCommands.Substring(0, reportCommands.Length - 4);
+            }
+
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60)); // 60 seconds timeout
+            var result =
+                await SshClientService.ExecuteCommandWithResponseAsync(deviceConfig, reportCommands, cts.Token);
+
+            if (result == null || string.IsNullOrEmpty(result.Result))
+            {
+                UpdateUIMessage("Failed to generate system report. No data received.");
+                return;
+            }
+
+            string reportContent = result.Result;
+
+            // Let the user know the report was generated
+            UpdateUIMessage("System report generated. Select a location to save it...");
+
+            // Now prompt the user for a save location
+            // Use Avalonia's SaveFileDialog to let the user pick a location
+            var saveFileDialog = new Avalonia.Controls.SaveFileDialog
+            {
+                Title = "Save System Report",
+                DefaultExtension = "txt",
+                InitialFileName = $"system_report_{DateTime.Now:yyyyMMdd_HHmmss}.txt",
+                Filters = new List<Avalonia.Controls.FileDialogFilter>
+                {
+                    new Avalonia.Controls.FileDialogFilter
+                    {
+                        Name = "Text Files",
+                        Extensions = new List<string> { "txt" }
+                    },
+                    new Avalonia.Controls.FileDialogFilter
+                    {
+                        Name = "All Files",
+                        Extensions = new List<string> { "*" }
+                    }
+                }
+            };
+
+            // Get the main window to show the dialog
+            var mainWindow =
+                Avalonia.Application.Current.ApplicationLifetime is
+                    Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime desktop
+                    ? desktop.MainWindow
+                    : null;
+
+            if (mainWindow == null)
+            {
+                UpdateUIMessage("Could not show save dialog. Using default location.");
+                // Save to a default location if we can't show the dialog
+                string defaultPath = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
+                    $"system_report_{DateTime.Now:yyyyMMdd_HHmmss}.txt");
+
+                File.WriteAllText(defaultPath, reportContent);
+                UpdateUIMessage($"System report saved to: {defaultPath}");
+                return;
+            }
+
+            // Show the save dialog and get the selected path
+            string filePath = await saveFileDialog.ShowAsync(mainWindow);
+
+            if (string.IsNullOrEmpty(filePath))
+            {
+                // User canceled the save operation
+                UpdateUIMessage("Save operation canceled.");
+                return;
+            }
+
+            // Save the report to the selected file
+            File.WriteAllText(filePath, reportContent);
+
+            UpdateUIMessage($"System report saved to: {filePath}");
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "Failed to generate system report");
+            UpdateUIMessage($"Error generating system report: {ex.Message}");
+        }
+    }
+
+    private async Task ViewSystemLogsAsync()
+    {
+        try
+        {
+            var deviceConfig = DeviceConfig.Instance;
+            if (!deviceConfig.CanConnect)
+            {
+                UpdateUIMessage("Device not connected. Cannot view system logs.");
+                return;
+            }
+
+            UpdateUIMessage("Retrieving system logs...");
+
+            // Execute command to get both journalctl and readlog output
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60)); // 60 seconds timeout
+
+            // Build combined log command
+            string logCommand =
+                "echo '=== Journal Logs (Last 100 Entries) ===' && " +
+                "journalctl -n 100 2>/dev/null || echo 'journalctl not available' && " +
+                "echo -e '\\n\\n=== OpenIPC readlog Output ===' && " +
+                "logread 2>/dev/null || echo 'logread command not available'";
+
+            var logResult = await SshClientService.ExecuteCommandWithResponseAsync(deviceConfig, logCommand, cts.Token);
+
+            if (logResult == null || string.IsNullOrEmpty(logResult.Result))
+            {
+                UpdateUIMessage("Failed to retrieve system logs. No data received.");
+                return;
+            }
+
+            string logContent = logResult.Result;
+
+            // Let the user know the logs were retrieved
+            UpdateUIMessage("System logs retrieved. Select a location to save them...");
+
+            // Prompt the user for a save location using SaveFileDialog
+            var saveFileDialog = new Avalonia.Controls.SaveFileDialog
+            {
+                Title = "Save System Logs",
+                DefaultExtension = "txt",
+                InitialFileName = $"system_logs_{DateTime.Now:yyyyMMdd_HHmmss}.txt",
+                Filters = new List<Avalonia.Controls.FileDialogFilter>
+                {
+                    new Avalonia.Controls.FileDialogFilter
+                    {
+                        Name = "Text Files",
+                        Extensions = new List<string> { "txt" }
+                    },
+                    new Avalonia.Controls.FileDialogFilter
+                    {
+                        Name = "All Files",
+                        Extensions = new List<string> { "*" }
+                    }
+                }
+            };
+
+            // Get the main window to show the dialog
+            var mainWindow =
+                Avalonia.Application.Current.ApplicationLifetime is
+                    Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime desktop
+                    ? desktop.MainWindow
+                    : null;
+
+            if (mainWindow == null)
+            {
+                UpdateUIMessage("Could not show save dialog. Using default location.");
+                // Save to a default location if we can't show the dialog
+                string defaultPath = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
+                    $"system_logs_{DateTime.Now:yyyyMMdd_HHmmss}.txt");
+
+                File.WriteAllText(defaultPath, logContent);
+                UpdateUIMessage($"System logs saved to: {defaultPath}");
+                return;
+            }
+
+            // Show the save dialog and get the selected path
+            string filePath = await saveFileDialog.ShowAsync(mainWindow);
+
+            if (string.IsNullOrEmpty(filePath))
+            {
+                // User canceled the save operation
+                UpdateUIMessage("Save operation canceled.");
+                return;
+            }
+
+            // Save the logs to the selected file
+            File.WriteAllText(filePath, logContent);
+
+            UpdateUIMessage($"System logs saved to: {filePath}");
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "Failed to retrieve system logs");
+            UpdateUIMessage($"Error retrieving system logs: {ex.Message}");
+        }
+    }
+
+    private async Task NetworkDiagnosticsAsync()
+    {
+        try
+        {
+            var deviceConfig = DeviceConfig.Instance;
+            if (!deviceConfig.CanConnect)
+            {
+                UpdateUIMessage("Device not connected. Cannot run network diagnostics.");
+                return;
+            }
+
+            UpdateUIMessage("Running network diagnostics...");
+
+            // Execute commands to diagnose network issues
+            string diagnosticCommands =
+                "echo '=== Network Interfaces ===' && " +
+                "ip addr && " +
+                "echo '=== Routing Table ===' && " +
+                "ip route && " +
+                "echo '=== DNS Configuration ===' && " +
+                "cat /etc/resolv.conf && " +
+                "echo '=== Ping Test (Google DNS) ===' && " +
+                "ping -c 4 8.8.8.8 || echo 'Ping failed' && " +
+                "echo '=== Wireless Interfaces ===' && " +
+                "iwconfig 2>/dev/null || echo 'iwconfig not available' && " +
+                "echo '=== Wireless Status ===' && " +
+                "iwconfig wlan0 2>/dev/null || echo 'iwconfig wlan0 not available' && " +
+                "echo '=== Network Connection Stats ===' && " +
+                "netstat -tuln || echo 'netstat not available'";
+
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60)); // 60 seconds timeout
+            var diagnosticsResult =
+                await SshClientService.ExecuteCommandWithResponseAsync(deviceConfig, diagnosticCommands, cts.Token);
+
+            if (diagnosticsResult == null || string.IsNullOrEmpty(diagnosticsResult.Result))
+            {
+                UpdateUIMessage("Failed to run network diagnostics. No data received.");
+                return;
+            }
+
+            string diagnosticsContent = diagnosticsResult.Result;
+
+            // Let the user know the diagnostics were completed
+            UpdateUIMessage("Network diagnostics completed. Select a location to save the results...");
+
+            // Prompt the user for a save location using SaveFileDialog
+            var saveFileDialog = new Avalonia.Controls.SaveFileDialog
+            {
+                Title = "Save Network Diagnostics",
+                DefaultExtension = "txt",
+                InitialFileName = $"network_diagnostics_{DateTime.Now:yyyyMMdd_HHmmss}.txt",
+                Filters = new List<Avalonia.Controls.FileDialogFilter>
+                {
+                    new Avalonia.Controls.FileDialogFilter
+                    {
+                        Name = "Text Files",
+                        Extensions = new List<string> { "txt" }
+                    },
+                    new Avalonia.Controls.FileDialogFilter
+                    {
+                        Name = "All Files",
+                        Extensions = new List<string> { "*" }
+                    }
+                }
+            };
+
+            // Get the main window to show the dialog
+            var mainWindow =
+                Avalonia.Application.Current.ApplicationLifetime is
+                    Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime desktop
+                    ? desktop.MainWindow
+                    : null;
+
+            if (mainWindow == null)
+            {
+                UpdateUIMessage("Could not show save dialog. Using default location.");
+                // Save to a default location if we can't show the dialog
+                string defaultPath = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
+                    $"network_diagnostics_{DateTime.Now:yyyyMMdd_HHmmss}.txt");
+
+                File.WriteAllText(defaultPath, diagnosticsContent);
+                UpdateUIMessage($"Network diagnostics saved to: {defaultPath}");
+                return;
+            }
+
+            // Show the save dialog and get the selected path
+            string filePath = await saveFileDialog.ShowAsync(mainWindow);
+
+            if (string.IsNullOrEmpty(filePath))
+            {
+                // User canceled the save operation
+                UpdateUIMessage("Save operation canceled.");
+                return;
+            }
+
+            // Save the diagnostics to the selected file
+            File.WriteAllText(filePath, diagnosticsContent);
+
+            UpdateUIMessage($"Network diagnostics saved to: {filePath}");
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "Failed to run network diagnostics");
+            UpdateUIMessage($"Error running network diagnostics: {ex.Message}");
+        }
+    }
+
+    #endregion
+
+    #region Event Handlers
+
+    private void OnAppMessage(AppMessage message)
+    {
+        // Ensure update happens on UI thread
+        Dispatcher.UIThread.Invoke(async () =>
+        {
+            // Force update even if the value seems the same
+            bool wasConnected = CanConnect;
+            if (CanConnect != message.CanConnect)
+            {
+                CanConnect = message.CanConnect;
+            }
+
+            // Explicitly trigger property changed notification
+            OnPropertyChanged(nameof(CanConnect));
+
+            // If we've just connected, check the status
+            if (!wasConnected && CanConnect)
+            {
+                await CheckAdaptiveLinkStatusAsync();
+                await CheckAlinkDroneStatusAsync();
+            }
+        });
+    }
+
+    #endregion
+}

--- a/OpenIPC_Config/ViewModels/CameraSettingsTabViewModel.cs
+++ b/OpenIPC_Config/ViewModels/CameraSettingsTabViewModel.cs
@@ -181,7 +181,7 @@ public partial class CameraSettingsTabViewModel : ViewModelBase
 
     partial void OnSelectedFpvEnabledChanged(string value)
     {
-        Logger.Debug($"SlectedFpvEnabledChanged updated to {value}");
+        Logger.Debug($"SelectedFpvEnabledChanged updated to {value}");
         UpdateYamlConfig(Majestic.FpvEnabled, value);
     }
 

--- a/OpenIPC_Config/ViewModels/ConnectControlsViewModel.cs
+++ b/OpenIPC_Config/ViewModels/ConnectControlsViewModel.cs
@@ -224,7 +224,7 @@ public partial class ConnectControlsViewModel : ViewModelBase
         }
         catch (Exception ex)
         {
-            Logger.Error(ex, "Error occurred during ping");
+            Logger.Error( "Error occurred during ping");
             PingStatusColor = _offlineColorBrush;
         }
     }

--- a/OpenIPC_Config/ViewModels/MainViewModel.cs
+++ b/OpenIPC_Config/ViewModels/MainViewModel.cs
@@ -29,7 +29,7 @@ public partial class MainViewModel : ViewModelBase
     private DispatcherTimer _pingTimer;
     private readonly TimeSpan _pingInterval = TimeSpan.FromSeconds(1);
     private readonly TimeSpan _pingTimeout = TimeSpan.FromMilliseconds(500);
-
+    private readonly IMessageBoxService _messageBoxService;
     
     [ObservableProperty] private string _svgPath;
     private bool _isTabsCollapsed;
@@ -53,13 +53,14 @@ public partial class MainViewModel : ViewModelBase
         ISshClientService sshClientService,
         IEventSubscriptionService eventSubscriptionService,
         IServiceProvider serviceProvider,
-        IGlobalSettingsService globalSettingsService)
+        IGlobalSettingsService globalSettingsService,
+        IMessageBoxService messageBoxService)
         : base(logger, sshClientService, eventSubscriptionService)
     {
         
         _logger = logger?.ForContext(GetType()) ?? 
                  throw new ArgumentNullException(nameof(logger));
-        
+        _messageBoxService = messageBoxService;
         LoadSettings();
         
         // Initialize the ping service
@@ -740,6 +741,9 @@ public partial class MainViewModel : ViewModelBase
             AppMessage>(new AppMessage { CanConnect = DeviceConfig.Instance.CanConnect, DeviceConfig = _deviceConfig });
 
         _logger.Information("Done reading files from device.");
+
+        _messageBoxService.ShowMessageBox("Read Device", "Done reading from device!");
+
     }
 
     private async Task GetAndComputeAirMd5Hash()

--- a/OpenIPC_Config/ViewModels/MainViewModel.cs
+++ b/OpenIPC_Config/ViewModels/MainViewModel.cs
@@ -124,6 +124,8 @@ public partial class MainViewModel : ViewModelBase
                 _serviceProvider.GetRequiredService<SetupTabViewModel>(), IsTabsCollapsed));
             Tabs.Add(new TabItemViewModel("Firmware", "avares://OpenIPC_Config/Assets/Icons/iconair_firmware_dark.svg",
                 _serviceProvider.GetRequiredService<FirmwareTabViewModel>(), IsTabsCollapsed));
+            Tabs.Add(new TabItemViewModel("Advanced", "avares://OpenIPC_Config/Assets/Icons/iconair_advanced_dark.svg",
+                _serviceProvider.GetRequiredService<AdvancedTabViewModel>(), IsTabsCollapsed));
         }
         else if (deviceType == DeviceType.Radxa)
         {

--- a/OpenIPC_Config/Views/AdvancedTabView.axaml
+++ b/OpenIPC_Config/Views/AdvancedTabView.axaml
@@ -4,10 +4,18 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:OpenIPC_Config"
              xmlns:viewModels="clr-namespace:OpenIPC_Config.ViewModels"
+             xmlns:converters="clr-namespace:OpenIPC_Config.Converters"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="OpenIPC_Config.Views.AdvancedTabView"
              x:DataType="viewModels:AdvancedTabViewModel">
-    
+
+    <UserControl.Resources>
+        <!-- Converters -->
+        <converters:InvertedBooleanConverter x:Key="InvertedBooleanConverter" />
+
+
+    </UserControl.Resources>
+
     <ScrollViewer>
         <StackPanel Orientation="Vertical" Margin="10">
             <!-- Info Panel -->
@@ -17,13 +25,14 @@
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="*" />
                     </Grid.ColumnDefinitions>
-                    <Path Data="M10,20 A10,10 0 1,1 10,0 A10,10 0 1,1 10,20 Z M10,7 A1.5,1.5 0 1,0 10,4 A1.5,1.5 0 1,0 10,7 Z M9,8 L11,8 L11,14 L9,14 Z"
-                          Fill="White"
-                          Width="20"
-                          Height="20"
-                          VerticalAlignment="Center"
-                          HorizontalAlignment="Center"
-                          Margin="5" />
+                    <Path
+                        Data="M10,20 A10,10 0 1,1 10,0 A10,10 0 1,1 10,20 Z M10,7 A1.5,1.5 0 1,0 10,4 A1.5,1.5 0 1,0 10,7 Z M9,8 L11,8 L11,14 L9,14 Z"
+                        Fill="White"
+                        Width="20"
+                        Height="20"
+                        VerticalAlignment="Center"
+                        HorizontalAlignment="Center"
+                        Margin="5" />
                     <TextBlock Grid.Column="1"
                                Text="This tab contains various experimental and advanced features."
                                Foreground="Black"
@@ -33,7 +42,7 @@
                                Margin="10,0,0,0" />
                 </Grid>
             </Border>
-            
+
             <!-- Feature Sections Container -->
             <ItemsControl>
                 <ItemsControl.ItemsPanel>
@@ -41,146 +50,114 @@
                         <StackPanel Spacing="16" />
                     </ItemsPanelTemplate>
                 </ItemsControl.ItemsPanel>
-                
+
                 <ItemsControl.Items>
                     <!-- Section 1: Adaptive Link -->
                     <Border Background="#F0F0F0" CornerRadius="8" Padding="16">
                         <StackPanel>
                             <!-- Section Header -->
                             <Grid ColumnDefinitions="*, Auto">
-                                <TextBlock Grid.Column="0" 
-                                           Text="Adaptive Link" 
-                                           FontSize="16" 
-                                           FontWeight="SemiBold" 
-                                           Margin="0,0,0,10"/>
-                                
+                                <TextBlock Grid.Column="0"
+                                           Text="Adaptive Link"
+                                           FontSize="16"
+                                           FontWeight="SemiBold"
+                                           Margin="0,0,0,10" />
+
                                 <!-- Running Status (Green) -->
-                                <StackPanel Grid.Column="1" 
-                                            Orientation="Horizontal" 
+                                <StackPanel Grid.Column="1"
+                                            Orientation="Horizontal"
                                             VerticalAlignment="Center"
                                             IsVisible="{Binding IsAdaptiveLinkRunning}">
-                                    <Ellipse Width="10" 
-                                             Height="10" 
+                                    <Ellipse Width="10"
+                                             Height="10"
                                              Fill="#4CAF50"
-                                             Margin="0,0,5,0"/>
-                                    <TextBlock Text="Running" 
-                                              FontSize="12"
-                                              Foreground="#4CAF50"
-                                              Margin="0,0,10,0"/>
-                                    <!-- <TextBlock Text="{Binding AdaptiveLinkVersion}"  -->
-                                    <!--            FontSize="12" -->
-                                    <!--            Opacity="0.7"/> -->
+                                             Margin="0,0,5,0" />
+                                    <TextBlock Text="Running"
+                                               FontSize="12"
+                                               Foreground="#4CAF50"
+                                               Margin="0,0,10,0" />
                                 </StackPanel>
-                                
-                                
-                                
+
+
                                 <!-- Installed But Not Running Status (Orange) -->
-                                <StackPanel Grid.Column="1" 
-                                            Orientation="Horizontal" 
+                                <StackPanel Grid.Column="1"
+                                            Orientation="Horizontal"
                                             VerticalAlignment="Center"
                                             IsVisible="{Binding InstalledButNotRunning}">
-                                    <Ellipse Width="10" 
-                                             Height="10" 
+                                    <Ellipse Width="10"
+                                             Height="10"
                                              Fill="#FFA000"
-                                             Margin="0,0,5,0"/>
-                                    <TextBlock Text="Installed" 
-                                              FontSize="12"
-                                              Foreground="#FFA000"
-                                              Margin="0,0,10,0"/>
+                                             Margin="0,0,5,0" />
+                                    <TextBlock Text="Installed"
+                                               FontSize="12"
+                                               Foreground="#FFA000"
+                                               Margin="0,0,10,0" />
                                     <!-- <TextBlock Text="{Binding AdaptiveLinkVersion}"  -->
                                     <!--            FontSize="12" -->
                                     <!--            Opacity="0.7"/> -->
                                 </StackPanel>
                             </Grid>
-                            
-                            <StackPanel Grid.Column="0" Orientation="Horizontal" Margin="0,5,0,0">
-                                <TextBlock VerticalAlignment="Center" Margin="0,0,10,0">Alink Drone on Boot:</TextBlock>
-                                <RadioButton GroupName="grpAlinkDrone" Content="Enabled" 
-                                             IsChecked="{Binding IsAlinkDroneEnabled}" 
-                                             IsEnabled="{Binding CanConnect}" />
-                                <RadioButton GroupName="grpAlinkDrone" Content="Disabled" 
-                                             IsChecked="{Binding !IsAlinkDroneEnabled}" 
-                                             IsEnabled="{Binding CanConnect}"
-                                             Margin="10,0,0,0" />
+
+
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock VerticalAlignment="Center">Alink Drone on Boot:</TextBlock>
+                                <ToggleSwitch IsChecked="{Binding IsAlinkDroneEnabled}"
+                                              IsEnabled="{Binding CanConnect}"
+                                              OnContent="Enabled"
+                                              OffContent="Disabled" />
                             </StackPanel>
-                            
-                            <!-- Section Description -->
-                            <TextBlock TextWrapping="Wrap"
-                                      Margin="0,0,0,16">
-                                <Run>Install and configure adaptive link for dynamic bandwidth adjustments based on signal quality.</Run>
-                                <LineBreak/>
-                                <LineBreak/>
-                                <Run>This will install the latest adaptive-link software from GitHub and configure it for drone operation.</Run>
-                                <LineBreak/>
-                                <Run FontWeight="SemiBold">Note: The device will reboot after installation.</Run>
-                            </TextBlock>
-                            
-                            <!-- Installation Status -->
-                            <Border Background="#EEEEEE" BorderBrush="#CCCCCC" BorderThickness="1" CornerRadius="4" 
-                                    Padding="10" Margin="0,0,0,16" IsVisible="{Binding IsAdaptiveLinkInstalling}">
-                                <StackPanel>
-                                    <TextBlock Text="Installation Progress:" FontWeight="SemiBold" Margin="0,0,0,5"/>
-                                    <TextBlock Text="{Binding AdaptiveLinkInstallStatus}" TextWrapping="Wrap"/>
-                                    <ProgressBar Value="{Binding AdaptiveLinkInstallProgress}" Maximum="100" 
-                                                Height="8" Margin="0,5,0,0"/>
-                                </StackPanel>
-                            </Border>
-                            
+
+
                             <!-- Not Installed Message -->
-                            <Border Background="#EEEEEE" BorderBrush="#CCCCCC" BorderThickness="1" CornerRadius="4" 
-                                    Padding="10" Margin="0,0,0,16" 
+                            <Border Background="#EEEEEE" BorderBrush="#CCCCCC" BorderThickness="1" CornerRadius="4"
+                                    Padding="10" Margin="0,0,0,16"
                                     IsVisible="{Binding NotInstalled}">
-                                <TextBlock Text="Adaptive Link is not installed on this device." 
+                                <TextBlock Text="Adaptive Link is not installed on this device."
                                            FontStyle="Italic"
-                                           TextWrapping="Wrap"/>
+                                           TextWrapping="Wrap" />
                             </Border>
-                            
+
                             <!-- Section Actions -->
                             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                                <Button Content="Check Installation Status" 
-                                       Command="{Binding CheckAdaptiveLinkStatusCommand}"
-                                       IsEnabled="{Binding CanConnect}"
-                                       Margin="0,0,10,0"/>
-                                
-                                <Button Content="Install Adaptive Link" 
-                                       Command="{Binding InstallAdaptiveLinkCommand}"
-                                       Background="#007ACC"
-                                       Foreground="White"
-                                       IsEnabled="{Binding CanInstall}"/>
+                                <Button Content="Check Installation Status"
+                                        Command="{Binding CheckAdaptiveLinkStatusCommand}"
+                                        IsEnabled="{Binding CanConnect}"
+                                        Margin="0,0,10,0" />
+
                             </StackPanel>
                         </StackPanel>
                     </Border>
-                    
+
                     <!-- Section 2: Debug Tools -->
                     <Border Background="#F0F0F0" CornerRadius="8" Padding="16">
                         <StackPanel>
                             <!-- Section Header -->
-                            <TextBlock Text="Debug Tools" 
-                                      FontSize="16" 
-                                      FontWeight="SemiBold" 
-                                      Margin="0,0,0,10"/>
-                            
+                            <TextBlock Text="Debug Tools"
+                                       FontSize="16"
+                                       FontWeight="SemiBold"
+                                       Margin="0,0,0,10" />
+
                             <!-- Section Description -->
                             <TextBlock Text="Advanced debugging tools and system diagnostics."
-                                      TextWrapping="Wrap"
-                                      Margin="0,0,0,16"/>
-                            
+                                       TextWrapping="Wrap"
+                                       Margin="0,0,0,16" />
+
                             <!-- Section Controls -->
-                            <WrapPanel Orientation="Horizontal" >
-                                <Button Content="Generate System Report" 
+                            <WrapPanel Orientation="Horizontal">
+                                <Button Content="Generate System Report"
                                         IsEnabled="{Binding CanConnect}"
                                         Command="{Binding GenerateSystemReportCommand}"
-                                        Margin="0,0,8,8"/>
-                                
-                                <Button Content="View System Logs" 
+                                        Margin="0,0,8,8" />
+
+                                <Button Content="View System Logs"
                                         IsEnabled="{Binding CanConnect}"
                                         Command="{Binding ViewSystemLogsCommand}"
-                                        Margin="0,0,8,8"/>
-                                
-                                <Button Content="Network Diagnostics" 
+                                        Margin="0,0,8,8" />
+
+                                <Button Content="Network Diagnostics"
                                         IsEnabled="{Binding CanConnect}"
                                         Command="{Binding NetworkDiagnosticsCommand}"
-                                        Margin="0,0,8,8"/>
+                                        Margin="0,0,8,8" />
                             </WrapPanel>
                         </StackPanel>
                     </Border>

--- a/OpenIPC_Config/Views/AdvancedTabView.axaml
+++ b/OpenIPC_Config/Views/AdvancedTabView.axaml
@@ -1,0 +1,191 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:OpenIPC_Config"
+             xmlns:viewModels="clr-namespace:OpenIPC_Config.ViewModels"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="OpenIPC_Config.Views.AdvancedTabView"
+             x:DataType="viewModels:AdvancedTabViewModel">
+    
+    <ScrollViewer>
+        <StackPanel Orientation="Vertical" Margin="10">
+            <!-- Info Panel -->
+            <Border Background="#B0B0B0" CornerRadius="10" Padding="10" Margin="0,0,0,16">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Path Data="M10,20 A10,10 0 1,1 10,0 A10,10 0 1,1 10,20 Z M10,7 A1.5,1.5 0 1,0 10,4 A1.5,1.5 0 1,0 10,7 Z M9,8 L11,8 L11,14 L9,14 Z"
+                          Fill="White"
+                          Width="20"
+                          Height="20"
+                          VerticalAlignment="Center"
+                          HorizontalAlignment="Center"
+                          Margin="5" />
+                    <TextBlock Grid.Column="1"
+                               Text="This tab contains various experimental and advanced features."
+                               Foreground="Black"
+                               FontSize="14"
+                               TextWrapping="Wrap"
+                               VerticalAlignment="Center"
+                               Margin="10,0,0,0" />
+                </Grid>
+            </Border>
+            
+            <!-- Feature Sections Container -->
+            <ItemsControl>
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <StackPanel Spacing="16" />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                
+                <ItemsControl.Items>
+                    <!-- Section 1: Adaptive Link -->
+                    <Border Background="#F0F0F0" CornerRadius="8" Padding="16">
+                        <StackPanel>
+                            <!-- Section Header -->
+                            <Grid ColumnDefinitions="*, Auto">
+                                <TextBlock Grid.Column="0" 
+                                           Text="Adaptive Link" 
+                                           FontSize="16" 
+                                           FontWeight="SemiBold" 
+                                           Margin="0,0,0,10"/>
+                                
+                                <!-- Running Status (Green) -->
+                                <StackPanel Grid.Column="1" 
+                                            Orientation="Horizontal" 
+                                            VerticalAlignment="Center"
+                                            IsVisible="{Binding IsAdaptiveLinkRunning}">
+                                    <Ellipse Width="10" 
+                                             Height="10" 
+                                             Fill="#4CAF50"
+                                             Margin="0,0,5,0"/>
+                                    <TextBlock Text="Running" 
+                                              FontSize="12"
+                                              Foreground="#4CAF50"
+                                              Margin="0,0,10,0"/>
+                                    <!-- <TextBlock Text="{Binding AdaptiveLinkVersion}"  -->
+                                    <!--            FontSize="12" -->
+                                    <!--            Opacity="0.7"/> -->
+                                </StackPanel>
+                                
+                                
+                                
+                                <!-- Installed But Not Running Status (Orange) -->
+                                <StackPanel Grid.Column="1" 
+                                            Orientation="Horizontal" 
+                                            VerticalAlignment="Center"
+                                            IsVisible="{Binding InstalledButNotRunning}">
+                                    <Ellipse Width="10" 
+                                             Height="10" 
+                                             Fill="#FFA000"
+                                             Margin="0,0,5,0"/>
+                                    <TextBlock Text="Installed" 
+                                              FontSize="12"
+                                              Foreground="#FFA000"
+                                              Margin="0,0,10,0"/>
+                                    <!-- <TextBlock Text="{Binding AdaptiveLinkVersion}"  -->
+                                    <!--            FontSize="12" -->
+                                    <!--            Opacity="0.7"/> -->
+                                </StackPanel>
+                            </Grid>
+                            
+                            <StackPanel Grid.Column="0" Orientation="Horizontal" Margin="0,5,0,0">
+                                <TextBlock VerticalAlignment="Center" Margin="0,0,10,0">Alink Drone on Boot:</TextBlock>
+                                <RadioButton GroupName="grpAlinkDrone" Content="Enabled" 
+                                             IsChecked="{Binding IsAlinkDroneEnabled}" 
+                                             IsEnabled="{Binding CanConnect}" />
+                                <RadioButton GroupName="grpAlinkDrone" Content="Disabled" 
+                                             IsChecked="{Binding !IsAlinkDroneEnabled}" 
+                                             IsEnabled="{Binding CanConnect}"
+                                             Margin="10,0,0,0" />
+                            </StackPanel>
+                            
+                            <!-- Section Description -->
+                            <TextBlock TextWrapping="Wrap"
+                                      Margin="0,0,0,16">
+                                <Run>Install and configure adaptive link for dynamic bandwidth adjustments based on signal quality.</Run>
+                                <LineBreak/>
+                                <LineBreak/>
+                                <Run>This will install the latest adaptive-link software from GitHub and configure it for drone operation.</Run>
+                                <LineBreak/>
+                                <Run FontWeight="SemiBold">Note: The device will reboot after installation.</Run>
+                            </TextBlock>
+                            
+                            <!-- Installation Status -->
+                            <Border Background="#EEEEEE" BorderBrush="#CCCCCC" BorderThickness="1" CornerRadius="4" 
+                                    Padding="10" Margin="0,0,0,16" IsVisible="{Binding IsAdaptiveLinkInstalling}">
+                                <StackPanel>
+                                    <TextBlock Text="Installation Progress:" FontWeight="SemiBold" Margin="0,0,0,5"/>
+                                    <TextBlock Text="{Binding AdaptiveLinkInstallStatus}" TextWrapping="Wrap"/>
+                                    <ProgressBar Value="{Binding AdaptiveLinkInstallProgress}" Maximum="100" 
+                                                Height="8" Margin="0,5,0,0"/>
+                                </StackPanel>
+                            </Border>
+                            
+                            <!-- Not Installed Message -->
+                            <Border Background="#EEEEEE" BorderBrush="#CCCCCC" BorderThickness="1" CornerRadius="4" 
+                                    Padding="10" Margin="0,0,0,16" 
+                                    IsVisible="{Binding NotInstalled}">
+                                <TextBlock Text="Adaptive Link is not installed on this device." 
+                                           FontStyle="Italic"
+                                           TextWrapping="Wrap"/>
+                            </Border>
+                            
+                            <!-- Section Actions -->
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                                <Button Content="Check Installation Status" 
+                                       Command="{Binding CheckAdaptiveLinkStatusCommand}"
+                                       IsEnabled="{Binding CanConnect}"
+                                       Margin="0,0,10,0"/>
+                                
+                                <Button Content="Install Adaptive Link" 
+                                       Command="{Binding InstallAdaptiveLinkCommand}"
+                                       Background="#007ACC"
+                                       Foreground="White"
+                                       IsEnabled="{Binding CanInstall}"/>
+                            </StackPanel>
+                        </StackPanel>
+                    </Border>
+                    
+                    <!-- Section 2: Debug Tools -->
+                    <Border Background="#F0F0F0" CornerRadius="8" Padding="16">
+                        <StackPanel>
+                            <!-- Section Header -->
+                            <TextBlock Text="Debug Tools" 
+                                      FontSize="16" 
+                                      FontWeight="SemiBold" 
+                                      Margin="0,0,0,10"/>
+                            
+                            <!-- Section Description -->
+                            <TextBlock Text="Advanced debugging tools and system diagnostics."
+                                      TextWrapping="Wrap"
+                                      Margin="0,0,0,16"/>
+                            
+                            <!-- Section Controls -->
+                            <WrapPanel Orientation="Horizontal" >
+                                <Button Content="Generate System Report" 
+                                        IsEnabled="{Binding CanConnect}"
+                                        Command="{Binding GenerateSystemReportCommand}"
+                                        Margin="0,0,8,8"/>
+                                
+                                <Button Content="View System Logs" 
+                                        IsEnabled="{Binding CanConnect}"
+                                        Command="{Binding ViewSystemLogsCommand}"
+                                        Margin="0,0,8,8"/>
+                                
+                                <Button Content="Network Diagnostics" 
+                                        IsEnabled="{Binding CanConnect}"
+                                        Command="{Binding NetworkDiagnosticsCommand}"
+                                        Margin="0,0,8,8"/>
+                            </WrapPanel>
+                        </StackPanel>
+                    </Border>
+                </ItemsControl.Items>
+            </ItemsControl>
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/OpenIPC_Config/Views/AdvancedTabView.axaml.cs
+++ b/OpenIPC_Config/Views/AdvancedTabView.axaml.cs
@@ -1,0 +1,19 @@
+using Avalonia;
+using Avalonia.Controls;
+using Microsoft.Extensions.DependencyInjection;
+using OpenIPC_Config.ViewModels;
+
+namespace OpenIPC_Config.Views;
+
+public partial class AdvancedTabView : UserControl
+{
+    public AdvancedTabView()
+    {
+        if (!Design.IsDesignMode) 
+            DataContext = App.ServiceProvider.GetService<AdvancedTabViewModel>();
+        
+        InitializeComponent();
+    }
+    
+    
+}

--- a/OpenIPC_Config/Views/FirmwareTabView.axaml.cs
+++ b/OpenIPC_Config/Views/FirmwareTabView.axaml.cs
@@ -10,6 +10,7 @@ public partial class FirmwareTabView : UserControl
     {
         InitializeComponent();
 
-        if (!Design.IsDesignMode) DataContext = App.ServiceProvider.GetService<FirmwareTabViewModel>();
+        if (!Design.IsDesignMode) 
+            DataContext = App.ServiceProvider.GetService<FirmwareTabViewModel>();
     }
 }

--- a/OpenIPC_Config/Views/TelemetryTabView.axaml
+++ b/OpenIPC_Config/Views/TelemetryTabView.axaml
@@ -138,16 +138,7 @@
                         HorizontalAlignment="Right"
                         ToolTip.Tip="{x:Static assets:Resources.MSPOSDExtraRemovalToolTip}" />
 
-                <StackPanel Grid.Row="7" Grid.Column="3" Grid.ColumnSpan="4" Orientation="Horizontal" Margin="0,5,0,0">
-                    <TextBlock VerticalAlignment="Center" Margin="0,0,10,0">Alink Drone on Boot:</TextBlock>
-                    <RadioButton GroupName="grpAlinkDrone" Content="Enabled" 
-                                 IsChecked="{Binding IsAlinkDroneEnabled}" 
-                                 IsEnabled="{Binding CanConnect}" />
-                    <RadioButton GroupName="grpAlinkDrone" Content="Disabled" 
-                                 IsChecked="{Binding !IsAlinkDroneEnabled}" 
-                                 IsEnabled="{Binding CanConnect}"
-                                 Margin="10,0,0,0" />
-                </StackPanel>
+                
 
                 <!-- ~1~ Onboard REC Toggle with RadioButtons @1@ -->
                 <!-- <ToggleSwitch Grid.Row="6" Grid.Column="4"  -->


### PR DESCRIPTION
## Description

This merge request adds a new Advanced tab to the application, providing enhanced configuration options for advanced users. The implementation includes:

- Creation of a new Advanced configuration interface
- Addition of advanced settings and customization options
- Improved user experience for power users

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

This PR fixes or closes issue: fixes #

## Motivation and Context

The Advanced tab allows users to:
- Access more granular configuration options
- Fine-tune application behavior
- Customize settings beyond basic configuration

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] 🚀 New feature (non-breaking change which adds functionality)
-   [ ] 🌎 Translation (addition or update a translation)
-   [ ] ⚙️ Tech (code style improvement, performance improvement or dependencies bump)
-   [ ] 📚 Documentation (fix or addition in the documentation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have tested the change locally.
