### PR TITLE
Fix update checks for older installs missing UpdateChecker config

### DIFF
--- a/Companion/App.axaml.cs
+++ b/Companion/App.axaml.cs
@@ -147,9 +147,18 @@ public class App : Application
                 existingSettings["UpdateChecker"] = new JObject(
                     new JProperty("LatestJsonUrl", "https://github.com/OpenIPC/companion/releases/latest/download/latest.json")
                 );
-                
+
                 hasChanges = true;
-                Log.Information("Added Presets section to existing settings");
+                Log.Information("Updated UpdateChecker settings in existing settings");
+            }
+            else
+            {
+                existingSettings["UpdateChecker"] = new JObject(
+                    new JProperty("LatestJsonUrl", "https://github.com/OpenIPC/companion/releases/latest/download/latest.json")
+                );
+
+                hasChanges = true;
+                Log.Information("Added UpdateChecker settings to existing settings");
             }
             // Check if Presets section exists, add if missing
             if (existingSettings["Presets"] == null)

--- a/Companion/Services/UpdateChecker.cs
+++ b/Companion/Services/UpdateChecker.cs
@@ -9,6 +9,9 @@ namespace Companion.Services;
 
 public class UpdateChecker
 {
+    private const string DefaultLatestJsonUrl =
+        "https://github.com/OpenIPC/companion/releases/latest/download/latest.json";
+
     private readonly HttpClient _httpClient;
     private readonly string _latestJsonUrl;
 
@@ -16,6 +19,8 @@ public class UpdateChecker
     {
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         _latestJsonUrl = configuration["UpdateChecker:LatestJsonUrl"];
+        if (string.IsNullOrWhiteSpace(_latestJsonUrl))
+            _latestJsonUrl = DefaultLatestJsonUrl;
     }
 
 


### PR DESCRIPTION
## Summary
- Add a safe fallback URL for update checks when UpdateChecker config is missing/empty.
- Ensure UpdateChecker is added to existing appsettings.json during config migration.

## Why
Older installs without an UpdateChecker section were never updated after the repo rename, causing update checks to fail.

## Testing
- Not run (config-only change)
