### PR TITLE
Build tests before coverage run

### DIFF
--- a/.github/workflows/gen-test-coverage-report.yml
+++ b/.github/workflows/gen-test-coverage-report.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Build project
         run: dotnet build Companion.Desktop/Companion.Desktop.csproj --configuration Release --no-restore
 
+      - name: Build tests
+        run: dotnet build Companion.Tests/Companion.Tests.csproj --configuration Release --no-restore
+
       - name: Run tests with coverage
         run: dotnet test Companion.Tests/Companion.Tests.csproj --configuration Release --no-build --verbosity normal --logger "trx" --collect:"XPlat Code Coverage"
 


### PR DESCRIPTION
## Summary
- Build Companion.Tests before running coverage to avoid missing test assembly.

## Why
Test run for /Users/mcarr/RiderProjects/companion/Companion.Tests/bin/Debug/net8.0/Companion.Tests.dll (.NETCoreApp,Version=v8.0)
VSTest version 17.11.0 (arm64) was failing when the test DLL wasn't built.

## Testing
- Not run (workflow change)
