### PR TITLE
Allow artifact cleanup in coverage workflow

### DIFF
--- a/.github/workflows/gen-test-coverage-report.yml
+++ b/.github/workflows/gen-test-coverage-report.yml
@@ -11,6 +11,7 @@ jobs:
   coverage:
     permissions:
       contents: read
+      actions: write
       pull-requests: write
       checks: write
 


### PR DESCRIPTION
## Summary
- Grant actions:write permission so the artifact cleanup step can delete old artifacts.

## Why
 failed with "Resource not accessible by integration" due to insufficient permissions.

## Testing
- Not run (workflow permission change)
