### PR TITLE
fix(linux): fix config path for Linux

### DIFF
--- a/Companion/App.axaml.cs
+++ b/Companion/App.axaml.cs
@@ -288,7 +288,8 @@ public class App : Application
         }
         else // Assume Linux
         {
-            var configDirectory = Path.Combine($"./config/{appName}");
+            var configDirectory =
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), appName.Replace(" ", ""));
             if (!Directory.Exists(configDirectory))
                 Directory.CreateDirectory(configDirectory);
 

--- a/Companion/Models/OpenIPC.cs
+++ b/Companion/Models/OpenIPC.cs
@@ -167,7 +167,8 @@ public class OpenIPC
         }
         else // Assume Linux
         {
-            AppDataConfigDirectory = Path.Combine($"./config/{appName}");
+            AppDataConfigDirectory =
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), appName);
             AppDataConfigPath = Path.Combine(AppDataConfigDirectory, "appsettings.json");
             DeviceSettingsConfigPath = Path.Combine(AppDataConfigDirectory, "OpenIPC.Companion.json");
             LocalTempFolder = Path.Combine(AppDataConfigDirectory, "Temp");

--- a/Companion/Models/OpenIPC.cs
+++ b/Companion/Models/OpenIPC.cs
@@ -168,7 +168,7 @@ public class OpenIPC
         else // Assume Linux
         {
             AppDataConfigDirectory =
-                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), appName);
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), appName.Replace(" ", ""));
             AppDataConfigPath = Path.Combine(AppDataConfigDirectory, "appsettings.json");
             DeviceSettingsConfigPath = Path.Combine(AppDataConfigDirectory, "OpenIPC.Companion.json");
             LocalTempFolder = Path.Combine(AppDataConfigDirectory, "Temp");


### PR DESCRIPTION
## Summary
- Replace relative `./config/OpenIPC Companion` path with `~/.local/share/OpenIPCCompanion` using `Environment.SpecialFolder.LocalApplicationData`
- Fix duplicate Linux path bug in `App.axaml.cs` `GetConfigPath()` which was causing `appsettings.json` to be written to the wrong location
- Remove space from app name on Linux (`OpenIPC Companion` → `OpenIPCCompanion`) to avoid path issues

## Test plan
- [ ] Launch app on Linux and verify config directory is created at `~/.local/share/OpenIPCCompanion/`
- [ ] Verify `appsettings.json` is created in that directory on first launch
- [ ] Verify logs are written to `~/.local/share/OpenIPCCompanion/Logs/Companion.log`
- [ ] Verify macOS and Windows behaviour is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)