### PR TITLE
fix: set default IP and password for first run

### DIFF
--- a/Companion/Services/SettingsManager.cs
+++ b/Companion/Services/SettingsManager.cs
@@ -60,9 +60,9 @@ public static class SettingsManager
         // Default values if no settings file exists or an error occurs
         return new DeviceConfig
         {
-            IpAddress = "",
+            IpAddress = "192.168.1.10",
             Username = "",
-            Password = "",
+            Password = "12345",
             DeviceType = DeviceType.Camera,
         };
     }

--- a/Companion/Services/SettingsManager.cs
+++ b/Companion/Services/SettingsManager.cs
@@ -61,7 +61,7 @@ public static class SettingsManager
         return new DeviceConfig
         {
             IpAddress = "192.168.1.10",
-            Username = "",
+            Username = "root",
             Password = "12345",
             DeviceType = DeviceType.Camera,
         };


### PR DESCRIPTION
## Summary
- Default IP address to `192.168.1.10` on first launch instead of empty string
- Default password to `12345` on first launch instead of empty string
- Values are still saved/loaded from settings file after first use as before

## Test plan
- [x] Delete or rename existing settings file and launch app — verify IP and password fields are pre-filled
- [ ] Enter different values, restart app — verify saved values are loaded correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)