### PR TITLE
ui(firmware): replace OR-separated sections with radio-button cards

### DIFF
--- a/Companion/Converters/IntToBoolConverter.cs
+++ b/Companion/Converters/IntToBoolConverter.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+
+namespace Companion.Converters;
+
+public class IntToBoolConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is int intValue && parameter is string paramStr && int.TryParse(paramStr, out var paramInt))
+            return intValue == paramInt;
+        return false;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is true && parameter is string paramStr && int.TryParse(paramStr, out var paramInt))
+            return paramInt;
+        return Avalonia.Data.BindingOperations.DoNothing;
+    }
+}

--- a/Companion/ViewModels/FirmwareTabViewModel.cs
+++ b/Companion/ViewModels/FirmwareTabViewModel.cs
@@ -109,6 +109,7 @@ public partial class FirmwareTabViewModel : ViewModelBase
     [ObservableProperty] private bool _isFirmwareExpanded = true;
     [ObservableProperty] private bool _isBootloaderExpanded;
     [ObservableProperty] private string _selectedFirmwareSource;
+    [ObservableProperty] private int _selectedFirmwareMethod; // 0=Automatic, 1=BySoc, 2=Local
 
     #endregion
 
@@ -308,6 +309,46 @@ public partial class FirmwareTabViewModel : ViewModelBase
         _bRecursionSelectGuard = false;
         UpdateCanExecuteCommands();
     }
+
+    partial void OnSelectedFirmwareMethodChanged(int value)
+    {
+        if (_bRecursionSelectGuard)
+            return;
+
+        _bRecursionSelectGuard = true;
+
+        // Clear selections from other methods
+        if (value != 0) // Not Automatic
+        {
+            SelectedManufacturer = string.Empty;
+            SelectedDevice = string.Empty;
+            SelectedFirmware = string.Empty;
+            IsManufacturerDeviceFirmwareComboSelected = false;
+        }
+
+        if (value != 1) // Not BySoc
+        {
+            SelectedFirmwareBySoc = string.Empty;
+            IsFirmwareBySocSelected = false;
+        }
+
+        if (value != 2) // Not Local
+        {
+            ManualLocalFirmwarePackageFile = string.Empty;
+            IsLocalFirmwarePackageSelected = false;
+        }
+
+        _bRecursionSelectGuard = false;
+
+        OnPropertyChanged(nameof(IsAutomaticMethodSelected));
+        OnPropertyChanged(nameof(IsBySocMethodSelected));
+        OnPropertyChanged(nameof(IsLocalMethodSelected));
+        UpdateCanExecuteCommands();
+    }
+
+    public bool IsAutomaticMethodSelected => SelectedFirmwareMethod == 0;
+    public bool IsBySocMethodSelected => SelectedFirmwareMethod == 1;
+    public bool IsLocalMethodSelected => SelectedFirmwareMethod == 2;
 
     partial void OnSelectedFirmwareSourceChanged(string value)
     {
@@ -607,7 +648,8 @@ public partial class FirmwareTabViewModel : ViewModelBase
         IsLocalFirmwarePackageSelected = false;
         IsManufacturerDeviceFirmwareComboSelected = false;
         IsManualUpdateEnabled = true;
-        
+        SelectedFirmwareMethod = 0;
+
         UpdateCanExecuteCommands();
     }
 
@@ -660,6 +702,9 @@ public partial class FirmwareTabViewModel : ViewModelBase
         OnPropertyChanged(nameof(CanUseDropdownsBySoc));
         OnPropertyChanged(nameof(CanUseSelectLocalFirmwarePackage));
         OnPropertyChanged(nameof(CanReplaceBootloader));
+        OnPropertyChanged(nameof(IsAutomaticMethodSelected));
+        OnPropertyChanged(nameof(IsBySocMethodSelected));
+        OnPropertyChanged(nameof(IsLocalMethodSelected));
 
         if (IsConnected)
         {

--- a/Companion/Views/FirmwareTabView.axaml
+++ b/Companion/Views/FirmwareTabView.axaml
@@ -11,6 +11,7 @@
              x:DataType="vm:FirmwareTabViewModel">
     <UserControl.Resources>
         <converters:InvertedBooleanConverter x:Key="InvertedBooleanConverter" />
+        <converters:IntToBoolConverter x:Key="IntToBoolConverter" />
     </UserControl.Resources>
 
     <UserControl.Styles>
@@ -28,6 +29,23 @@
         </Style>
         <Style Selector="ComboBox.firmware-combo">
             <Setter Property="Width" Value="{x:Static sys:Double.NaN}" />
+        </Style>
+        <!-- Firmware method card styles -->
+        <Style Selector="Border.fw-card">
+            <Setter Property="Background" Value="#E7E7E7" />
+            <Setter Property="CornerRadius" Value="8" />
+            <Setter Property="Padding" Value="12" />
+            <Setter Property="BorderThickness" Value="2" />
+            <Setter Property="BorderBrush" Value="Transparent" />
+            <Setter Property="Margin" Value="0,0,0,4" />
+        </Style>
+        <Style Selector="Border.fw-card-active">
+            <Setter Property="Background" Value="#E7E7E7" />
+            <Setter Property="CornerRadius" Value="8" />
+            <Setter Property="Padding" Value="12" />
+            <Setter Property="BorderThickness" Value="2" />
+            <Setter Property="BorderBrush" Value="{StaticResource OpenIPCBlueBrush}" />
+            <Setter Property="Margin" Value="0,0,0,4" />
         </Style>
     </UserControl.Styles>
 
@@ -62,7 +80,7 @@
                                   HorizontalAlignment="Center"
                                   Margin="5" />
                             <TextBlock Grid.Column="1"
-                                       Text="This tab is used to flash firmware to your camera. There are three ways of selecting firmware. We strongly recommend the first, automatic."
+                                       Text="Select a firmware source below. Choose one method — the selected card will highlight."
                                        Foreground="Black"
                                        FontSize="14"
                                        TextWrapping="Wrap"
@@ -72,142 +90,152 @@
                     </Border>
 
                     <Border Background="#F0F0F0" CornerRadius="8" Padding="16" Margin="8">
-                        <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,*"
-                              ColumnDefinitions="*,Auto,*"
-                              ShowGridLines="False">
+                        <StackPanel Orientation="Vertical" Spacing="4">
 
-                            <Border Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3" Background="#E7E7E7" CornerRadius="8" Padding="5">
-                                <Grid RowDefinitions="Auto,Auto,Auto,Auto"
-                                      ColumnDefinitions="Auto,*"
-                                      HorizontalAlignment="Stretch"
-                                      ShowGridLines="False">
-                                    <!-- Firmware Source -->
-                                    <TextBlock Text="Firmware Source" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" />
-                                    <ComboBox Grid.Row="0" Grid.Column="1"
-                                              Classes="firmware-combo"
-                                              IsEnabled="{Binding CanUseDropdownsBySoc}"
-                                              SelectedItem="{Binding SelectedFirmwareSource, Mode=TwoWay}"
-                                              ItemsSource="{Binding FirmwareSources}"
-                                              HorizontalAlignment="Left"
-                                              Margin="10,0,0,0"
-                                              Background="#E7E7E7" />
+                            <!-- === Card 1: Automatic (by manufacturer) === -->
+                            <Border Classes.fw-card-active="{Binding IsAutomaticMethodSelected}"
+                                    Classes.fw-card="{Binding !IsAutomaticMethodSelected}">
+                                <StackPanel Orientation="Vertical" Spacing="8">
+                                    <RadioButton GroupName="FirmwareMethod"
+                                                 FontWeight="SemiBold"
+                                                 Content="Automatic — by manufacturer"
+                                                 IsChecked="{Binding SelectedFirmwareMethod, Converter={StaticResource IntToBoolConverter}, ConverterParameter=0}" />
+                                    <Grid RowDefinitions="Auto,Auto,Auto,Auto"
+                                          ColumnDefinitions="Auto,*"
+                                          HorizontalAlignment="Stretch"
+                                          ShowGridLines="False"
+                                          IsVisible="{Binding IsAutomaticMethodSelected}">
+                                        <!-- Firmware Source -->
+                                        <TextBlock Text="Firmware Source" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" />
+                                        <ComboBox Grid.Row="0" Grid.Column="1"
+                                                  Classes="firmware-combo"
+                                                  IsEnabled="{Binding CanUseDropdownsBySoc}"
+                                                  SelectedItem="{Binding SelectedFirmwareSource, Mode=TwoWay}"
+                                                  ItemsSource="{Binding FirmwareSources}"
+                                                  HorizontalAlignment="Left"
+                                                  Margin="10,0,0,0"
+                                                  Background="#E7E7E7" />
 
-                                    <!-- Manufacturer -->
-                                    <TextBlock Text="Manufacturer" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" />
-                                    <ComboBox Grid.Row="1" Grid.Column="1"
-                                              Classes="firmware-combo"
-                                              IsEnabled="{Binding CanUseDropdowns}"
-                                              SelectedItem="{Binding SelectedManufacturer, Mode=TwoWay}"
-                                              ItemsSource="{Binding Manufacturers}"
-                                              HorizontalAlignment="Left"
-                                              Margin="10,0,0,0"
-                                              Background="#E7E7E7" />
+                                        <!-- Manufacturer -->
+                                        <TextBlock Text="Manufacturer" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" />
+                                        <ComboBox Grid.Row="1" Grid.Column="1"
+                                                  Classes="firmware-combo"
+                                                  IsEnabled="{Binding CanUseDropdowns}"
+                                                  SelectedItem="{Binding SelectedManufacturer, Mode=TwoWay}"
+                                                  ItemsSource="{Binding Manufacturers}"
+                                                  HorizontalAlignment="Left"
+                                                  Margin="10,0,0,0"
+                                                  Background="#E7E7E7" />
 
-                                    <!-- Device -->
-                                    <TextBlock Text="Device" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" />
-                                    <ComboBox Grid.Row="2" Grid.Column="1"
-                                              Classes="firmware-combo"
-                                              IsEnabled="{Binding CanUseDropdowns}"
-                                              SelectedItem="{Binding SelectedDevice, Mode=TwoWay}"
-                                              ItemsSource="{Binding Devices}"
-                                              HorizontalAlignment="Left"
-                                              Margin="10,0,0,0"
-                                              Background="#E7E7E7" />
+                                        <!-- Device -->
+                                        <TextBlock Text="Device" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" />
+                                        <ComboBox Grid.Row="2" Grid.Column="1"
+                                                  Classes="firmware-combo"
+                                                  IsEnabled="{Binding CanUseDropdowns}"
+                                                  SelectedItem="{Binding SelectedDevice, Mode=TwoWay}"
+                                                  ItemsSource="{Binding Devices}"
+                                                  HorizontalAlignment="Left"
+                                                  Margin="10,0,0,0"
+                                                  Background="#E7E7E7" />
 
-                                    <!-- WFB/Ruby -->
-                                    <TextBlock Text="WFB/Ruby" Grid.Row="3" Grid.Column="0" VerticalAlignment="Center" />
-                                    <ComboBox Grid.Row="3" Grid.Column="1"
-                                              Classes="firmware-combo"
-                                              IsEnabled="{Binding CanUseDropdowns}"
-                                              SelectedItem="{Binding SelectedFirmware, Mode=TwoWay}"
-                                              ItemsSource="{Binding Firmwares}"
-                                              HorizontalAlignment="Left"
-                                              Margin="10,0,0,0"
-                                              Background="#E7E7E7" />
-                                </Grid>
+                                        <!-- WFB/Ruby -->
+                                        <TextBlock Text="WFB/Ruby" Grid.Row="3" Grid.Column="0" VerticalAlignment="Center" />
+                                        <ComboBox Grid.Row="3" Grid.Column="1"
+                                                  Classes="firmware-combo"
+                                                  IsEnabled="{Binding CanUseDropdowns}"
+                                                  SelectedItem="{Binding SelectedFirmware, Mode=TwoWay}"
+                                                  ItemsSource="{Binding Firmwares}"
+                                                  HorizontalAlignment="Left"
+                                                  Margin="10,0,0,0"
+                                                  Background="#E7E7E7" />
+                                    </Grid>
+                                </StackPanel>
                             </Border>
 
-                            <TextBlock Text="OR" Grid.Row="1" Grid.Column="1" Padding="0,5,0,5" VerticalAlignment="Center" />
-
-                            <!-- Choice Section -->
-                            <Border Grid.Row="4" Grid.Column="0"  Grid.ColumnSpan="3" Background="#E7E7E7" CornerRadius="8" Padding="5">
-                                <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto"
-                                      HorizontalAlignment="Stretch"
-                                      ToolTip.Tip="{x:Static assets:Resources.FirmwareChoiceToolTip}">
-                                    <TextBlock Text="Select Firmware" Grid.Row="0" Grid.Column="0"
-                                               IsEnabled="{Binding CanUseDropdowns}"
-                                               VerticalAlignment="Center" />
-
-                                    <ComboBox Grid.Row="0" Grid.Column="1"
-                                              Classes="firmware-combo"
-                                              HorizontalAlignment="Left"
-                                              Margin="10,0,0,0"
-                                              IsEnabled="{Binding CanUseDropdownsBySoc}"
-                                              SelectedItem="{Binding SelectedFirmwareBySoc, Mode=TwoWay}"
-                                              ItemsSource="{Binding FirmwareBySoc}"
-                                              Background="#E7E7E7" />
-                                </Grid>
+                            <!-- === Card 2: Select by SoC === -->
+                            <Border Classes.fw-card-active="{Binding IsBySocMethodSelected}"
+                                    Classes.fw-card="{Binding !IsBySocMethodSelected}">
+                                <StackPanel Orientation="Vertical" Spacing="8">
+                                    <RadioButton GroupName="FirmwareMethod"
+                                                 FontWeight="SemiBold"
+                                                 Content="Select by SoC"
+                                                 IsChecked="{Binding SelectedFirmwareMethod, Converter={StaticResource IntToBoolConverter}, ConverterParameter=1}" />
+                                    <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto"
+                                          HorizontalAlignment="Stretch"
+                                          IsVisible="{Binding IsBySocMethodSelected}"
+                                          ToolTip.Tip="{x:Static assets:Resources.FirmwareChoiceToolTip}">
+                                        <TextBlock Text="Select Firmware" Grid.Row="0" Grid.Column="0"
+                                                   VerticalAlignment="Center" />
+                                        <ComboBox Grid.Row="0" Grid.Column="1"
+                                                  Classes="firmware-combo"
+                                                  HorizontalAlignment="Left"
+                                                  Margin="10,0,0,0"
+                                                  IsEnabled="{Binding CanUseDropdownsBySoc}"
+                                                  SelectedItem="{Binding SelectedFirmwareBySoc, Mode=TwoWay}"
+                                                  ItemsSource="{Binding FirmwareBySoc}"
+                                                  Background="#E7E7E7" />
+                                    </Grid>
+                                </StackPanel>
                             </Border>
 
-                            <TextBlock Text="OR" Grid.Row="5" Grid.Column="1" Padding="0,5,0,5" VerticalAlignment="Center" />
+                            <!-- === Card 3: Local file === -->
+                            <Border Classes.fw-card-active="{Binding IsLocalMethodSelected}"
+                                    Classes.fw-card="{Binding !IsLocalMethodSelected}">
+                                <StackPanel Orientation="Vertical" Spacing="8">
+                                    <RadioButton GroupName="FirmwareMethod"
+                                                 FontWeight="SemiBold"
+                                                 Content="Local file"
+                                                 IsChecked="{Binding SelectedFirmwareMethod, Converter={StaticResource IntToBoolConverter}, ConverterParameter=2}" />
+                                    <Grid ColumnDefinitions="Auto, Auto, Auto"
+                                          RowDefinitions="Auto"
+                                          ShowGridLines="False"
+                                          IsVisible="{Binding IsLocalMethodSelected}"
+                                          ToolTip.Tip="{x:Static assets:Resources.FirmwareLocalToolTip}">
 
-                            <!-- Manual Section -->
-                            <Border Grid.Column="0" Grid.Row="6" Grid.ColumnSpan="3" Background="#E7E7E7"
-                                    CornerRadius="8" Padding="5">
+                                        <TextBlock Text="Local" Grid.Row="0" Grid.Column="0"
+                                                   VerticalAlignment="Center" />
 
-                                <Grid ColumnDefinitions="Auto, Auto, Auto"
-                                      RowDefinitions="Auto, Auto"
-                                      ShowGridLines="False"
-                                      ToolTip.Tip="{x:Static assets:Resources.FirmwareLocalToolTip}">
+                                        <TextBlock Grid.Row="0" Grid.Column="1"
+                                                   Margin="5,0,0,0"
+                                                   Padding="5"
+                                                   Background="#F0F0F0"
+                                                   Width="400"
+                                                   Height="25"
+                                                   IsEnabled="{Binding CanUseSelectLocalFirmwarePackage}"
+                                                   Text="{Binding Path=ManualLocalFirmwarePackageFile, Mode=TwoWay}" />
 
-                                    <!-- Manual upload -->
-                                    <TextBlock Text="Local" Grid.Row="0" Grid.Column="0"
-                                               VerticalAlignment="Center" />
-
-                                    <TextBlock Grid.Row="0" Grid.Column="1"
-                                               Margin="5,0,0,0"
-                                               Padding="5"
-                                               Background="#F0F0F0"
-                                               Width="400"
-                                               Height="25"
-                                               IsEnabled="{Binding CanUseSelectLocalFirmwarePackage}"
-                                               Text="{Binding Path=ManualLocalFirmwarePackageFile, Mode=TwoWay}" />
-
-                                    <Button Grid.Row="0" Grid.Column="2" Content="..."
-                                            Margin="5,5,0,0"
-                                            VerticalAlignment="Center"
-                                            Background="LightGray"
-                                            IsEnabled="{Binding CanUseSelectLocalFirmwarePackage}"
-                                            Command="{Binding SelectLocalFirmwarePackageCommand}"
-                                            CommandParameter="{Binding RelativeSource={RelativeSource AncestorType=Window}}" />
-
-                                </Grid>
+                                        <Button Grid.Row="0" Grid.Column="2" Content="..."
+                                                Margin="5,0,0,0"
+                                                VerticalAlignment="Center"
+                                                Background="LightGray"
+                                                IsEnabled="{Binding CanUseSelectLocalFirmwarePackage}"
+                                                Command="{Binding SelectLocalFirmwarePackageCommand}"
+                                                CommandParameter="{Binding RelativeSource={RelativeSource AncestorType=Window}}" />
+                                    </Grid>
+                                </StackPanel>
                             </Border>
 
-                            <!-- Clear Button -->
-                            <Button Content="Clear"
-                                    Grid.Row="7"
-                                    Grid.Column="0"
-                                    HorizontalAlignment="Left"
-                                    Background="LightGray"
-                                    IsDefault="False"
-                                    Width="100"
-                                    Command="{Binding ClearFormCommand}"
-                                    IsEnabled="{Binding CanConnect}"
-                                    Margin="5,10,0,0" />
+                            <!-- Buttons -->
+                            <Grid ColumnDefinitions="*,*" Margin="0,8,0,0">
+                                <Button Content="Clear"
+                                        Grid.Column="0"
+                                        HorizontalAlignment="Left"
+                                        Background="LightGray"
+                                        IsDefault="False"
+                                        Width="100"
+                                        Command="{Binding ClearFormCommand}"
+                                        IsEnabled="{Binding CanConnect}" />
 
-                            <!-- Update Button -->
-                            <Button Content="Update"
-                                    Grid.Row="7"
-                                    Grid.Column="2"
-                                    IsDefault="True"
-                                    HorizontalAlignment="Right"
-                                    Width="100"
-                                    Command="{Binding PerformFirmwareUpgradeAsyncCommand}"
-                                    IsEnabled="{Binding CanConnect}"
-                                    Margin="0,10,0,0" />
+                                <Button Content="Update"
+                                        Grid.Column="1"
+                                        IsDefault="True"
+                                        HorizontalAlignment="Right"
+                                        Width="100"
+                                        Command="{Binding PerformFirmwareUpgradeAsyncCommand}"
+                                        IsEnabled="{Binding CanConnect}" />
+                            </Grid>
 
-                        </Grid>
+                        </StackPanel>
                     </Border>
 
                     <Border Background="#F0F0F0" CornerRadius="8" Padding="16" Margin="8">


### PR DESCRIPTION
## Summary
- Replaced the three firmware selection methods (Automatic, By SoC, Local file) that were stacked with "OR" text dividers with radio-button cards
- Only the selected card expands to show its controls; unselected cards collapse to just their header
- Active card gets an OpenIPC blue border for clear visual feedback
- Added `IntToBoolConverter` for two-way RadioButton ↔ int binding
- Added `SelectedFirmwareMethod` property to ViewModel with automatic clearing of other methods' selections on switch

## Test plan
- [x] Build passes (0 errors)
- [x] All 48 tests pass
- [x] App launches and Firmware tab renders correctly
- [ ] Verify switching between radio cards clears selections from other methods
- [ ] Verify firmware upgrade flow still works end-to-end with each method
- [ ] Verify Clear button resets to Automatic method