### PR TITLE
fix(ui): use theme-aware colors in PreferencesTabView for dark mode s…

### DIFF
--- a/Companion/Views/PreferencesTabView.axaml
+++ b/Companion/Views/PreferencesTabView.axaml
@@ -11,23 +11,25 @@
 
     <ScrollViewer>
         <StackPanel Orientation="Vertical" Margin="10" Spacing="16">
-            <Border Background="#B0B0B0" CornerRadius="10" Padding="10">
+            <Border Background="{DynamicResource WarningBannerBackground}" CornerRadius="10" Padding="10">
                 <TextBlock Text="Application preferences are stored per user in the app data folder and apply across supported desktop platforms."
-                           Foreground="Black"
+                           Foreground="{DynamicResource PrimaryTextForeground}"
                            FontSize="14"
                            TextWrapping="Wrap" />
             </Border>
 
-            <Border Background="#F0F0F0" CornerRadius="8" Padding="16">
+            <Border Background="{DynamicResource CardBackground}" CornerRadius="8" Padding="16">
                 <StackPanel Spacing="14">
                     <TextBlock Text="General"
                                FontSize="16"
-                               FontWeight="SemiBold" />
+                               FontWeight="SemiBold"
+                               Foreground="{DynamicResource PrimaryTextForeground}" />
 
                     <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto,Auto,Auto">
                         <TextBlock Grid.Row="0" Grid.Column="0"
                                    Text="Check for updates on startup"
                                    VerticalAlignment="Center"
+                                   Foreground="{DynamicResource PrimaryTextForeground}"
                                    Margin="0,0,12,12" />
                         <ToggleSwitch Grid.Row="0" Grid.Column="1"
                                       HorizontalAlignment="Left"
@@ -39,6 +41,7 @@
                         <TextBlock Grid.Row="1" Grid.Column="0"
                                    Text="Firmware focused mode"
                                    VerticalAlignment="Center"
+                                   Foreground="{DynamicResource PrimaryTextForeground}"
                                    Margin="0,0,12,12" />
                         <ToggleSwitch Grid.Row="1" Grid.Column="1"
                                       HorizontalAlignment="Left"
@@ -49,7 +52,7 @@
 
                         <Border Grid.Row="2"
                                 Grid.Column="1"
-                                Background="#E7E7E7"
+                                Background="{DynamicResource InputFieldBackground}"
                                 CornerRadius="6"
                                 Padding="10"
                                 Margin="0,0,0,12"
@@ -57,12 +60,14 @@
                                 MaxWidth="460">
                             <TextBlock Text="When enabled: WFB, Camera, Telemetry, and Setup are hidden for camera workflows, and camera connections land on Firmware. Preferences are saved automatically and applied when the application is reopened."
                                        TextWrapping="Wrap"
+                                       Foreground="{DynamicResource LabelForeground}"
                                        Opacity="0.8" />
                         </Border>
 
                         <TextBlock Grid.Row="3" Grid.Column="0"
                                    Text="Preferred firmware source"
                                    VerticalAlignment="Center"
+                                   Foreground="{DynamicResource PrimaryTextForeground}"
                                    Margin="0,0,12,0" />
                         <ComboBox Grid.Row="3" Grid.Column="1"
                                   Width="220"
@@ -73,15 +78,17 @@
                 </StackPanel>
             </Border>
 
-            <Border Background="#F0F0F0" CornerRadius="8" Padding="16">
+            <Border Background="{DynamicResource CardBackground}" CornerRadius="8" Padding="16">
                 <StackPanel>
                     <TextBlock Text="Debug Tools"
                                FontSize="16"
                                FontWeight="SemiBold"
+                               Foreground="{DynamicResource PrimaryTextForeground}"
                                Margin="0,0,0,10" />
 
                     <TextBlock Text="Advanced debugging tools and system diagnostics."
                                TextWrapping="Wrap"
+                               Foreground="{DynamicResource LabelForeground}"
                                Margin="0,0,0,16" />
 
                     <WrapPanel Orientation="Horizontal">
@@ -99,6 +106,7 @@
 
             <TextBlock Text="{Binding StatusMessage}"
                        FontStyle="Italic"
+                       Foreground="{DynamicResource LabelForeground}"
                        Opacity="0.7" />
         </StackPanel>
     </ScrollViewer>


### PR DESCRIPTION
…upport

Replaced hardcoded light-mode colors (#F0F0F0, #B0B0B0, #E7E7E7, Black) with DynamicResource references (CardBackground, WarningBannerBackground, InputFieldBackground, PrimaryTextForeground, LabelForeground) so all text and backgrounds adapt correctly to both light and dark themes.

https://claude.ai/code/session_01SqHUbH2pgbXBaVbkDw1vuD

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

This PR fixes or closes issue: fixes #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] 🚀 New feature (non-breaking change which adds functionality)
-   [ ] 🌎 Translation (addition or update a translation)
-   [ ] ⚙️ Tech (code style improvement, performance improvement or dependencies bump)
-   [ ] 📚 Documentation (fix or addition in the documentation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have tested the change locally.
