### PR TITLE
Fix settings defaults on startup load

### DIFF
--- a/Companion.Tests/Services/SettingsManagerTests.cs
+++ b/Companion.Tests/Services/SettingsManagerTests.cs
@@ -121,4 +121,47 @@ public class SettingsManagerTests
         Assert.That(result.Password, Is.EqualTo("12345"));
         Assert.That(result.DeviceType, Is.EqualTo(DeviceType.Camera));
     }
+
+    [Test]
+    public void LoadSettings_FileContainsNullsAndNone_NormalizesToDefaults()
+    {
+        var storedConfig = new DeviceConfig
+        {
+            IpAddress = null!,
+            Username = null!,
+            Password = null!,
+            DeviceType = DeviceType.None
+        };
+
+        File.WriteAllText(_testSettingsFilePath, JsonConvert.SerializeObject(storedConfig));
+
+        var result = SettingsManager.LoadSettings();
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.IpAddress, Is.EqualTo("192.168.1.10"));
+        Assert.That(result.Username, Is.EqualTo("root"));
+        Assert.That(result.Password, Is.EqualTo("12345"));
+        Assert.That(result.DeviceType, Is.EqualTo(DeviceType.Camera));
+    }
+
+    [Test]
+    public void SaveSettings_WhenValuesAreMissing_PersistsNormalizedDefaults()
+    {
+        var configToSave = new DeviceConfig
+        {
+            IpAddress = null!,
+            Username = null!,
+            Password = null!,
+            DeviceType = DeviceType.None
+        };
+
+        SettingsManager.SaveSettings(configToSave);
+
+        var savedConfig = JsonConvert.DeserializeObject<DeviceConfig>(File.ReadAllText(_testSettingsFilePath));
+        Assert.That(savedConfig, Is.Not.Null);
+        Assert.That(savedConfig!.IpAddress, Is.EqualTo("192.168.1.10"));
+        Assert.That(savedConfig.Username, Is.EqualTo("root"));
+        Assert.That(savedConfig.Password, Is.EqualTo("12345"));
+        Assert.That(savedConfig.DeviceType, Is.EqualTo(DeviceType.Camera));
+    }
 }

--- a/Companion/Services/SettingsManager.cs
+++ b/Companion/Services/SettingsManager.cs
@@ -9,6 +9,9 @@ namespace Companion.Services;
 public static class SettingsManager
 {
     private static readonly string AppSettingsName = "openipc_settings.json";
+    private const string DefaultIpAddress = "192.168.1.10";
+    private const string DefaultUsername = "root";
+    private const string DefaultPassword = "12345";
 
     public static string AppSettingFilename
     {
@@ -28,19 +31,14 @@ public static class SettingsManager
     /// </returns>
     public static DeviceConfig? LoadSettings()
     {
-        DeviceConfig deviceConfig;
-
         if (File.Exists(AppSettingFilename))
             try
             {
                 var json = File.ReadAllText(AppSettingFilename);
-                deviceConfig = JsonConvert.DeserializeObject<DeviceConfig>(json);
+                var deviceConfig = JsonConvert.DeserializeObject<DeviceConfig>(json);
 
                 if (deviceConfig != null)
-                    // Optionally publish an event if needed
-                    // eventAggregator?.GetEvent<DeviceStateUpdatedEvent>()?.Publish(
-                    //     new DeviceStateUpdatedMessage(true, deviceConfig));
-                    return deviceConfig;
+                    return NormalizeSettings(deviceConfig);
 
                 Log.Error("LoadSettings: deviceConfig is null. The file content might be corrupted.");
             }
@@ -58,13 +56,7 @@ public static class SettingsManager
             }
 
         // Default values if no settings file exists or an error occurs
-        return new DeviceConfig
-        {
-            IpAddress = "192.168.1.10",
-            Username = "root",
-            Password = "12345",
-            DeviceType = DeviceType.Camera,
-        };
+        return CreateDefaultSettings();
     }
 
 
@@ -77,7 +69,40 @@ public static class SettingsManager
     /// </remarks>
     public static void SaveSettings(DeviceConfig settings)
     {
-        var json = JsonConvert.SerializeObject(settings, Formatting.Indented);
+        var normalizedSettings = NormalizeSettings(settings);
+        var json = JsonConvert.SerializeObject(normalizedSettings, Formatting.Indented);
         File.WriteAllText(AppSettingFilename, json);
+    }
+
+    private static DeviceConfig CreateDefaultSettings()
+    {
+        return new DeviceConfig
+        {
+            IpAddress = DefaultIpAddress,
+            Username = DefaultUsername,
+            Password = DefaultPassword,
+            DeviceType = DeviceType.Camera,
+        };
+    }
+
+    private static DeviceConfig NormalizeSettings(DeviceConfig settings)
+    {
+        settings.IpAddress = string.IsNullOrWhiteSpace(settings.IpAddress)
+            ? DefaultIpAddress
+            : settings.IpAddress;
+
+        settings.Username = string.IsNullOrWhiteSpace(settings.Username)
+            ? DefaultUsername
+            : settings.Username;
+
+        settings.Password = string.IsNullOrWhiteSpace(settings.Password)
+            ? DefaultPassword
+            : settings.Password;
+
+        if (settings.DeviceType == DeviceType.None)
+            settings.DeviceType = DeviceType.Camera;
+
+        settings.CachedIpAddresses ??= new();
+        return settings;
     }
 }

--- a/Companion/ViewModels/ConnectControlsViewModel.cs
+++ b/Companion/ViewModels/ConnectControlsViewModel.cs
@@ -177,13 +177,14 @@ public partial class ConnectControlsViewModel : ViewModelBase
     private void LoadSettings()
     {
         var settings = SettingsManager.LoadSettings();
+        DeviceConfig.SetInstance(settings);
         _deviceConfig = DeviceConfig.Instance;
-        IpAddress = settings.IpAddress;
-        Password = settings.Password;
-        SelectedDeviceType = settings.DeviceType;
+        IpAddress = _deviceConfig.IpAddress;
+        Password = _deviceConfig.Password;
+        SelectedDeviceType = _deviceConfig.DeviceType;
         
         // Load cached IP addresses
-        CachedIpAddresses = new ObservableCollection<string>(settings.CachedIpAddresses ?? new List<string>());
+        CachedIpAddresses = new ObservableCollection<string>(_deviceConfig.CachedIpAddresses ?? new List<string>());
     
         // If current IP isn't in the cache and is valid, add it
         if (!string.IsNullOrEmpty(IpAddress) && 

--- a/Companion/ViewModels/MainViewModel.cs
+++ b/Companion/ViewModels/MainViewModel.cs
@@ -51,6 +51,7 @@ public partial class MainViewModel : ViewModelBase
     private readonly ILogger _logger;
     private UserPreferences _userPreferences;
     private bool _preferencesInitialized;
+    private bool _isLoadingSettings;
     
     [ObservableProperty] private bool _isWaiting;
     [ObservableProperty] private bool _isConnected;
@@ -991,23 +992,28 @@ public partial class MainViewModel : ViewModelBase
     private void LoadSettings()
     {
         IsWaiting = true;
-        // Load settings via the SettingsManager
-        var settings = SettingsManager.LoadSettings();
-        _deviceConfig = DeviceConfig.Instance;
-        IpAddress = settings.IpAddress;
-        Password = settings.Password;
-        Port = settings.Port == 0 ? 22 : settings.Port;
-        SelectedDeviceType = settings.DeviceType;
-        
-        // Load cached IP addresses first
-        CachedIpAddresses = new ObservableCollection<string>(settings.CachedIpAddresses ?? new List<string>());
+        _isLoadingSettings = true;
 
-        // Load theme preference
-        IsDarkTheme = settings.IsDarkTheme;
-        ApplyTheme();
+        try
+        {
+            var settings = SettingsManager.LoadSettings();
+            DeviceConfig.SetInstance(settings);
+            _deviceConfig = DeviceConfig.Instance;
 
-        // Publish the initial device type
-        EventSubscriptionService.Publish<DeviceTypeChangeEvent, DeviceType>(settings.DeviceType);
+            IpAddress = _deviceConfig.IpAddress;
+            Password = _deviceConfig.Password;
+            Port = _deviceConfig.Port == 0 ? 22 : _deviceConfig.Port;
+            SelectedDeviceType = _deviceConfig.DeviceType;
+            CachedIpAddresses = new ObservableCollection<string>(_deviceConfig.CachedIpAddresses ?? new List<string>());
+            IsDarkTheme = _deviceConfig.IsDarkTheme;
+            ApplyTheme();
+
+            EventSubscriptionService.Publish<DeviceTypeChangeEvent, DeviceType>(_deviceConfig.DeviceType);
+        }
+        finally
+        {
+            _isLoadingSettings = false;
+        }
     }
 
     private void RestoreSelectedTab()
@@ -1147,6 +1153,9 @@ public partial class MainViewModel : ViewModelBase
     partial void OnIsDarkThemeChanged(bool value)
     {
         ApplyTheme();
+        if (_isLoadingSettings)
+            return;
+
         if (_deviceConfig != null)
         {
             _deviceConfig.IsDarkTheme = value;


### PR DESCRIPTION
## Summary
- normalize missing device settings to the expected defaults
- seed DeviceConfig.Instance from loaded settings before startup saves can fire
- add tests covering null/None settings values
 
## Testing
- dotnet test Companion.Tests/Companion.Tests.csproj