### PR TITLE
Harden firmware upgrade UI flow

### DIFF
--- a/Companion/Events/FirmwareOperationStateChangedEvent.cs
+++ b/Companion/Events/FirmwareOperationStateChangedEvent.cs
@@ -1,0 +1,7 @@
+using Prism.Events;
+
+namespace Companion.Events;
+
+public class FirmwareOperationStateChangedEvent : PubSubEvent<bool>
+{
+}

--- a/Companion/Services/IMessageBoxService.cs
+++ b/Companion/Services/IMessageBoxService.cs
@@ -1,11 +1,12 @@
 using System.Threading.Tasks;
+using Avalonia.Controls;
 using MsBox.Avalonia.Enums;
 
 namespace Companion.Services;
 
 public interface IMessageBoxService
 {
-    Task ShowMessageBox(string title, string message);
-    Task<ButtonResult> ShowMessageBoxWithFolderLink(string title, string message, string filePath);
-    Task<ButtonResult> ShowCustomMessageBox(string title, string message, ButtonEnum buttons, Icon icon = Icon.Info);
+    Task ShowMessageBox(string title, string message, Window? owner = null);
+    Task<ButtonResult> ShowMessageBoxWithFolderLink(string title, string message, string filePath, Window? owner = null);
+    Task<ButtonResult> ShowCustomMessageBox(string title, string message, ButtonEnum buttons, Icon icon = Icon.Info, Window? owner = null);
 }

--- a/Companion/Services/MessageBoxService.cs
+++ b/Companion/Services/MessageBoxService.cs
@@ -1,9 +1,12 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
+using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
 using MsBox.Avalonia;
 using MsBox.Avalonia.Enums;
 using Companion.Services;
@@ -20,7 +23,7 @@ namespace Companion.Services;
             _logger = logger;
         }
         
-        public async Task ShowMessageBox(string title, string message)
+        public async Task ShowMessageBox(string title, string message, Window? owner = null)
         {
             var msgBox = MessageBoxManager.GetMessageBoxStandard(
                 title,
@@ -30,10 +33,10 @@ namespace Companion.Services;
                 WindowStartupLocation.CenterScreen
             );
 
-            await msgBox.ShowAsync();
+            await ShowMessageBoxAsync(msgBox, owner);
         }
         
-        public async Task<ButtonResult> ShowMessageBoxWithFolderLink(string title, string message, string filePath)
+        public async Task<ButtonResult> ShowMessageBoxWithFolderLink(string title, string message, string filePath, Window? owner = null)
         {
             // For folder operations, we'll use a custom approach instead
             var msgBox = MessageBoxManager.GetMessageBoxStandard(
@@ -44,7 +47,7 @@ namespace Companion.Services;
                 WindowStartupLocation.CenterScreen
             );
 
-            var result = await msgBox.ShowAsync();
+            var result = await ShowMessageBoxAsync(msgBox, owner);
             
             if (result == ButtonResult.Yes)
             {
@@ -91,7 +94,7 @@ namespace Companion.Services;
                     _logger.Error(ex, "Error opening folder");
                     
                     // Show an error message if the folder couldn't be opened
-                    await ShowMessageBox("Error", $"Could not open folder: {ex.Message}");
+                    await ShowMessageBox("Error", $"Could not open folder: {ex.Message}", owner);
                 }
             }
             
@@ -99,7 +102,7 @@ namespace Companion.Services;
         }
         
         // A more flexible version that accepts standard button configurations
-        public async Task<ButtonResult> ShowCustomMessageBox(string title, string message, ButtonEnum buttons, Icon icon = Icon.Info)
+        public async Task<ButtonResult> ShowCustomMessageBox(string title, string message, ButtonEnum buttons, Icon icon = Icon.Info, Window? owner = null)
         {
             var msgBox = MessageBoxManager.GetMessageBoxStandard(
                 title,
@@ -109,6 +112,23 @@ namespace Companion.Services;
                 WindowStartupLocation.CenterScreen
             );
 
-            return await msgBox.ShowAsync();
+            return await ShowMessageBoxAsync(msgBox, owner);
+        }
+
+        private static async Task<ButtonResult> ShowMessageBoxAsync(dynamic msgBox, Window? owner = null)
+        {
+            owner ??= ResolveOwnerWindow();
+            return owner != null
+                ? await msgBox.ShowWindowDialogAsync(owner)
+                : await msgBox.ShowAsync();
+        }
+
+        private static Window? ResolveOwnerWindow()
+        {
+            if (Application.Current?.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime desktop)
+                return null;
+
+            return desktop.Windows.FirstOrDefault(window => window.IsActive)
+                   ?? desktop.MainWindow;
         }
     }

--- a/Companion/ViewModels/FirmwareTabViewModel.cs
+++ b/Companion/ViewModels/FirmwareTabViewModel.cs
@@ -61,6 +61,7 @@ public partial class FirmwareTabViewModel : ViewModelBase
     private SysupgradePhase _sysupgradePhase = SysupgradePhase.None;
     private bool _sysupgradeInProgress = false;
     private DispatcherTimer _flashTimer;
+    private bool _lastPublishedDestructiveOperationState;
     private static readonly IBrush ProgressRunningBrush = Brushes.Green;
     private static readonly IBrush ProgressErrorBrush = Brushes.Red;
     private static readonly IBrush ProgressCompleteBrush = new SolidColorBrush(Color.Parse("#4C61D8"));
@@ -370,13 +371,15 @@ public partial class FirmwareTabViewModel : ViewModelBase
 
     private void HandleAppMessage(AppMessage message)
     {
+        var wasOperationInProgress = IsDestructiveOperationInProgress;
+
         CanConnect = message.CanConnect;
         IsConnected = message.CanConnect;
 
         _ = LoadManufacturersAsync();
         _ = LoadBootloadersAsync();
 
-        if (!IsConnected)
+        if (!IsConnected && !wasOperationInProgress)
         {
             IsLocalFirmwarePackageSelected = false;
             IsManufacturerDeviceFirmwareComboSelected = false;
@@ -855,6 +858,13 @@ public partial class FirmwareTabViewModel : ViewModelBase
             StartFlashTimer();
         else
             StopFlashTimer();
+
+        if (_lastPublishedDestructiveOperationState != IsDestructiveOperationInProgress)
+        {
+            _lastPublishedDestructiveOperationState = IsDestructiveOperationInProgress;
+            EventSubscriptionService.Publish<FirmwareOperationStateChangedEvent, bool>(IsDestructiveOperationInProgress);
+        }
+
         OnPropertyChanged(nameof(IsBySocMethodSelected));
         OnPropertyChanged(nameof(IsLocalMethodSelected));
 

--- a/Companion/ViewModels/LogViewerViewModel.cs
+++ b/Companion/ViewModels/LogViewerViewModel.cs
@@ -15,6 +15,8 @@ namespace Companion.ViewModels;
 /// </summary>
 public class LogViewerViewModel : ViewModelBase
 {
+    private const int MaxLogMessages = 1000;
+
     #region Private Fields
     private readonly IEventSubscriptionService _eventSubscriptionService;
     private int _duplicateCount;
@@ -140,7 +142,7 @@ public class LogViewerViewModel : ViewModelBase
         if (message.UpdateLogView)
         {
             var formattedMessage = FormatLogMessage(message.ToString());
-            Dispatcher.UIThread.InvokeAsync(() => LogMessages.Add(formattedMessage));
+            Dispatcher.UIThread.InvokeAsync(() => AddLogMessage(formattedMessage));
         }
     }
     #endregion
@@ -184,7 +186,7 @@ public class LogViewerViewModel : ViewModelBase
         _lastMessage = message;
 
         // Add new message to log
-        Dispatcher.UIThread.InvokeAsync(() => LogMessages.Add(formattedMessage));
+        Dispatcher.UIThread.InvokeAsync(() => AddLogMessage(formattedMessage));
     }
 
     /// <summary>
@@ -197,10 +199,18 @@ public class LogViewerViewModel : ViewModelBase
             var duplicateMessage = FormatLogMessage(
                 $"[Last message repeated {_duplicateCount} times]");
 
-            Dispatcher.UIThread.InvokeAsync(() => LogMessages.Add(duplicateMessage));
+            Dispatcher.UIThread.InvokeAsync(() => AddLogMessage(duplicateMessage));
             _duplicateCount = 0;
             _lastFlushTime = DateTime.Now;
         }
+    }
+
+    private void AddLogMessage(string message)
+    {
+        LogMessages.Add(message);
+
+        while (LogMessages.Count > MaxLogMessages)
+            LogMessages.RemoveAt(0);
     }
 
     public void NotifyDetachedFromLatest()

--- a/Companion/ViewModels/MainViewModel.cs
+++ b/Companion/ViewModels/MainViewModel.cs
@@ -58,6 +58,7 @@ public partial class MainViewModel : ViewModelBase
     
     [ObservableProperty] private ObservableCollection<string> _cachedIpAddresses = new();
     [ObservableProperty] private string _selectedCachedIpAddress;
+    [ObservableProperty] private bool _isTabNavigationEnabled = true;
 
 
     public MainViewModel(ILogger logger,
@@ -92,6 +93,7 @@ public partial class MainViewModel : ViewModelBase
         // Subscribe to device type change events
         EventSubscriptionService.Subscribe<DeviceTypeChangeEvent, DeviceType>(
             OnDeviceTypeChangeEvent);
+        EventSubscriptionService.Subscribe<FirmwareOperationStateChangedEvent, bool>(OnFirmwareOperationStateChanged);
 
         ToggleTabsCommand = new RelayCommand(() => IsTabsCollapsed = !IsTabsCollapsed);
         ToggleThemeCommand = new RelayCommand(() => IsDarkTheme = !IsDarkTheme);
@@ -195,6 +197,8 @@ public partial class MainViewModel : ViewModelBase
     public ICommand ToggleThemeCommand { get; }
     
     public ICommand OpenLogFolderCommand { get; }
+
+    public bool IsConnectEnabled => CanConnect && IsTabNavigationEnabled;
 
     public WfbTabViewModel WfbTabViewModel { get; }
     public WfbGSTabViewModel WfbGSTabViewModel { get; }
@@ -1192,6 +1196,27 @@ public partial class MainViewModel : ViewModelBase
 
         // Notify the view of tab changes
         //EventSubscriptionService.Publish<TabSelectionChangeEvent, string>(SelectedTab);
+    }
+
+    private void OnFirmwareOperationStateChanged(bool isInProgress)
+    {
+        if (!Dispatcher.UIThread.CheckAccess())
+        {
+            Dispatcher.UIThread.Post(() => OnFirmwareOperationStateChanged(isInProgress));
+            return;
+        }
+
+        IsTabNavigationEnabled = !isInProgress;
+    }
+
+    partial void OnCanConnectChanged(bool value)
+    {
+        OnPropertyChanged(nameof(IsConnectEnabled));
+    }
+
+    partial void OnIsTabNavigationEnabledChanged(bool value)
+    {
+        OnPropertyChanged(nameof(IsConnectEnabled));
     }
 
     #region Observable Properties

--- a/Companion/Views/FirmwareTabView.axaml
+++ b/Companion/Views/FirmwareTabView.axaml
@@ -287,7 +287,11 @@
                         </Grid>
                     </Border>
 
-                    <Border Background="{DynamicResource CardBackground}" CornerRadius="8" Padding="16" Margin="8">
+                    <Border Background="{DynamicResource CardBackground}"
+                            CornerRadius="8"
+                            Padding="16"
+                            Margin="8"
+                            IsEnabled="{Binding IsDestructiveOperationInProgress, Converter={StaticResource InvertedBooleanConverter}}">
                         <StackPanel Orientation="Vertical" Spacing="8">
                             <Grid ColumnDefinitions="Auto,*">
                                 <TextBlock Text="Firmware Source" Grid.Column="0" VerticalAlignment="Center" />

--- a/Companion/Views/HeaderView.axaml
+++ b/Companion/Views/HeaderView.axaml
@@ -31,6 +31,24 @@
         <Setter Property="Fill" Value="{DynamicResource CircularButtonHoverFill}" />
     </Style>
 
+    <Style Selector="Button.CircularButton:disabled /template/ Ellipse#ButtonBackground">
+        <Setter Property="Fill" Value="#5C5C5C" />
+        <Setter Property="Opacity" Value="0.75" />
+    </Style>
+
+    <Style Selector="Button.CircularButton:disabled">
+        <Setter Property="Opacity" Value="0.6" />
+    </Style>
+
+    <Style Selector="Button.CircularButton:disabled Path#IconPath">
+        <Setter Property="Fill" Value="#BFBFBF" />
+        <Setter Property="Opacity" Value="0.85" />
+    </Style>
+
+    <Style Selector="Button.CircularButton:disabled /template/ Ellipse#GlowEffect">
+        <Setter Property="Opacity" Value="0" />
+    </Style>
+
     <!-- Red pulse animation -->
     <Style Selector="Button.CircularButton.RedPulse /template/ Ellipse#GlowEffect">
         <Style.Animations>
@@ -187,7 +205,10 @@
             </Grid>
 
             <!-- Connection Fields -->
-            <Grid Grid.Column="3" HorizontalAlignment="Right" VerticalAlignment="Center">
+            <Grid Grid.Column="3"
+                  HorizontalAlignment="Right"
+                  VerticalAlignment="Center"
+                  IsEnabled="{Binding IsTabNavigationEnabled}">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
@@ -249,7 +270,7 @@
             <!-- Circular Connect Button -->
             <StackPanel Grid.Column="4" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="5,0,10,0">
                 <Button Width="50" Height="50" Command="{Binding ConnectCommand}"
-                        IsEnabled="{Binding CanConnect}"
+                        IsEnabled="{Binding IsConnectEnabled}"
                         Classes="CircularButton"
                         Classes.RedPulse="{Binding IsWaiting}"
                         Classes.GreenGlow="{Binding IsConnected}">

--- a/Companion/Views/LogViewer.axaml.cs
+++ b/Companion/Views/LogViewer.axaml.cs
@@ -13,6 +13,7 @@ public partial class LogViewer : UserControl
     private const double BottomThreshold = 24;
     private LogViewerViewModel? _currentViewModel;
     private bool _isProgrammaticScroll;
+    private bool _scrollToLatestQueued;
 
     public LogViewer()
     {
@@ -97,20 +98,22 @@ public partial class LogViewer : UserControl
 
     private void ScrollToLatest()
     {
+        if (_scrollToLatestQueued)
+            return;
+
+        _scrollToLatestQueued = true;
+
         Dispatcher.UIThread.Post(() =>
         {
-            SetScrollOffsetToLatest();
+            try
+            {
+                SetScrollOffsetToLatest();
+            }
+            finally
+            {
+                _scrollToLatestQueued = false;
+            }
         }, DispatcherPriority.Background);
-
-        Dispatcher.UIThread.Post(() =>
-        {
-            SetScrollOffsetToLatest();
-        }, DispatcherPriority.Loaded);
-
-        Dispatcher.UIThread.Post(() =>
-        {
-            SetScrollOffsetToLatest();
-        }, DispatcherPriority.Render);
     }
 
     private void SetScrollOffsetToLatest()

--- a/Companion/Views/MainView.axaml
+++ b/Companion/Views/MainView.axaml
@@ -39,6 +39,7 @@
                         ItemsSource="{Binding Tabs}"
                         SelectedIndex="{Binding SelectedTabIndex}"
                         SelectedItem="{Binding SelectedTab}"
+                        IsEnabled="{Binding IsTabNavigationEnabled}"
                         Width="{Binding IsTabsCollapsed, 
                         Converter={StaticResource BooleanToWidthConverter},
                         ConverterParameter='80,200'}"
@@ -73,6 +74,7 @@
             <Button Grid.Row="0" Grid.Column="1" HorizontalAlignment="Center" 
                     VerticalAlignment="Top"
                     Classes="DrawerButton"
+                    IsEnabled="{Binding IsTabNavigationEnabled}"
                     Command="{Binding ToggleTabsCommand}" 
                     BorderThickness="0"
                     Background="Transparent">


### PR DESCRIPTION
## Summary
- attach firmware completion dialogs to the app window so they do not get stranded behind the main window on macOS
- disable tab navigation, connection controls, and firmware selection controls during destructive firmware operations
- preserve firmware operation warning state across expected disconnects during upgrade
- reduce log viewer UI churn so jump-to-latest is less likely to stall the UI during active flashing
- 
## Testing
- dotnet build Companion/Companion.csproj
- dotnet test Companion.Tests/Companion.Tests.csproj