### PR TITLE
Use neutral icon for read device dialog

### DIFF
--- a/Companion/Services/IMessageBoxService.cs
+++ b/Companion/Services/IMessageBoxService.cs
@@ -6,7 +6,7 @@ namespace Companion.Services;
 
 public interface IMessageBoxService
 {
-    Task ShowMessageBox(string title, string message, Window? owner = null);
+    Task ShowMessageBox(string title, string message, Window? owner = null, Icon icon = Icon.Info);
     Task<ButtonResult> ShowMessageBoxWithFolderLink(string title, string message, string filePath, Window? owner = null);
     Task<ButtonResult> ShowCustomMessageBox(string title, string message, ButtonEnum buttons, Icon icon = Icon.Info, Window? owner = null);
 }

--- a/Companion/Services/MessageBoxService.cs
+++ b/Companion/Services/MessageBoxService.cs
@@ -23,13 +23,13 @@ namespace Companion.Services;
             _logger = logger;
         }
         
-        public async Task ShowMessageBox(string title, string message, Window? owner = null)
+        public async Task ShowMessageBox(string title, string message, Window? owner = null, Icon icon = Icon.Info)
         {
             var msgBox = MessageBoxManager.GetMessageBoxStandard(
                 title,
                 message,
                 ButtonEnum.Ok,
-                Icon.Info,
+                icon,
                 WindowStartupLocation.CenterScreen
             );
 
@@ -94,7 +94,7 @@ namespace Companion.Services;
                     _logger.Error(ex, "Error opening folder");
                     
                     // Show an error message if the folder couldn't be opened
-                    await ShowMessageBox("Error", $"Could not open folder: {ex.Message}", owner);
+                    await ShowMessageBox("Error", $"Could not open folder: {ex.Message}", owner, Icon.Error);
                 }
             }
             

--- a/Companion/ViewModels/MainViewModel.cs
+++ b/Companion/ViewModels/MainViewModel.cs
@@ -846,7 +846,7 @@ public partial class MainViewModel : ViewModelBase
 
         _logger.Information("Done reading files from device.");
 
-        _messageBoxService.ShowMessageBox("Read Device", "Done reading from device!");
+        _messageBoxService.ShowMessageBox("Read Device", "Done reading from device!", icon: Icon.None);
 
     }
 


### PR DESCRIPTION
## Summary

- change the `Read Device` completion dialog to use a neutral icon instead of a status icon
- avoid the misleading red magnifying-glass/checkmark appearance seen on macOS
- keep the existing dialog behavior otherwise unchanged

## Why

The current `Done reading from device` dialog looks like an error or warning on macOS because of how the dialog icon is rendered. This is confusing for a successful read operation.

## Change

- update the message box service usage so this dialog can request a specific icon
- set the `Read Device` completion dialog to `Icon.None`

## Testing

- ran `dotnet build Companion/Companion.csproj`
