### PR TITLE
Collapsible log panel and side panel cleanup

### DIFF
--- a/Companion/Assets/Icons/drawer-handle.svg
+++ b/Companion/Assets/Icons/drawer-handle.svg
@@ -1,3 +1,3 @@
-<svg width="9" height="433" viewBox="0 0 9 433" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path d="M0 0H4C6.76142 0 9 2.23858 9 5V428C9 430.761 6.76142 433 4 433H0V0Z" fill="#4C61D8"/>
+<svg width="3" height="433" viewBox="0 0 3 433" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect width="3" height="433" rx="1.5" fill="#4C61D8"/>
 </svg>

--- a/Companion/Models/UserPreferences.cs
+++ b/Companion/Models/UserPreferences.cs
@@ -7,4 +7,6 @@ public sealed class UserPreferences
     public bool FirmwareFocusedMode { get; set; } = true;
     public string LastSelectedTab { get; set; } = string.Empty;
     public bool IsTabsCollapsed { get; set; }
+    public double LogPanelHeight { get; set; } = 60;
+    public bool IsLogPanelCollapsed { get; set; }
 }

--- a/Companion/ViewModels/MainViewModel.cs
+++ b/Companion/ViewModels/MainViewModel.cs
@@ -37,6 +37,10 @@ public partial class MainViewModel : ViewModelBase
     
     [ObservableProperty] private string _svgPath;
     private bool _isTabsCollapsed;
+    private bool _isLogPanelCollapsed;
+    private double _logPanelHeight = 60;
+    private double _logPanelHeightBeforeCollapse = 60;
+    private const double DefaultLogHeight = 60;
 
     [ObservableProperty] private bool _isMobile;
     private DeviceType _selectedDeviceType;
@@ -87,6 +91,9 @@ public partial class MainViewModel : ViewModelBase
         _preferencesService = preferencesService;
         _userPreferences = _preferencesService.Load();
         _isTabsCollapsed = _userPreferences.IsTabsCollapsed;
+        _isLogPanelCollapsed = _userPreferences.IsLogPanelCollapsed;
+        _logPanelHeight = Math.Max(DefaultLogHeight, _userPreferences.LogPanelHeight);
+        _logPanelHeightBeforeCollapse = _logPanelHeight;
 
         Tabs = new ObservableCollection<TabItemViewModel> { };
         
@@ -105,6 +112,7 @@ public partial class MainViewModel : ViewModelBase
         DeviceTypes = new ObservableCollection<DeviceType>(Enum.GetValues(typeof(DeviceType)).Cast<DeviceType>());
         
         OpenLogFolderCommand = new RelayCommand(() => OpenLogFolder());
+        ToggleLogPanelCommand = new RelayCommand(() => IsLogPanelCollapsed = !IsLogPanelCollapsed);
 
         // Initialize the path
         UpdateSvgPath();
@@ -197,6 +205,39 @@ public partial class MainViewModel : ViewModelBase
     public ICommand ToggleThemeCommand { get; }
     
     public ICommand OpenLogFolderCommand { get; }
+    public ICommand ToggleLogPanelCommand { get; }
+
+    public bool IsLogPanelCollapsed
+    {
+        get => _isLogPanelCollapsed;
+        set
+        {
+            if (SetProperty(ref _isLogPanelCollapsed, value))
+            {
+                if (value)
+                {
+                    _logPanelHeightBeforeCollapse = _logPanelHeight;
+                }
+                else
+                {
+                    LogPanelHeight = _logPanelHeightBeforeCollapse >= DefaultLogHeight
+                        ? _logPanelHeightBeforeCollapse
+                        : DefaultLogHeight;
+                }
+                SavePreferences();
+            }
+        }
+    }
+
+    public double LogPanelHeight
+    {
+        get => _logPanelHeight;
+        set
+        {
+            if (SetProperty(ref _logPanelHeight, value))
+                SavePreferences();
+        }
+    }
 
     public bool IsConnectEnabled => CanConnect && IsTabNavigationEnabled;
 
@@ -1061,6 +1102,8 @@ public partial class MainViewModel : ViewModelBase
         _userPreferences = _preferencesService.Load();
         _userPreferences.IsTabsCollapsed = IsTabsCollapsed;
         _userPreferences.LastSelectedTab = SelectedTab?.TabName.Trim() ?? string.Empty;
+        _userPreferences.IsLogPanelCollapsed = IsLogPanelCollapsed;
+        _userPreferences.LogPanelHeight = IsLogPanelCollapsed ? _logPanelHeightBeforeCollapse : LogPanelHeight;
         _preferencesService.Save(_userPreferences);
     }
 

--- a/Companion/Views/MainView.axaml
+++ b/Companion/Views/MainView.axaml
@@ -42,7 +42,7 @@
                         IsEnabled="{Binding IsTabNavigationEnabled}"
                         Width="{Binding IsTabsCollapsed, 
                         Converter={StaticResource BooleanToWidthConverter},
-                        ConverterParameter='80,200'}"
+                        ConverterParameter='60,200'}"
                         Padding="0,0,10,0">
                 
                 <TabControl.ItemTemplate>
@@ -70,27 +70,12 @@
                 </TabControl.ItemTemplate>
             </TabControl>
 
-            <!-- Toggle Tabs Button -->
-            <Button Grid.Row="0" Grid.Column="1" HorizontalAlignment="Center" 
-                    VerticalAlignment="Top"
-                    Classes="DrawerButton"
-                    IsEnabled="{Binding IsTabNavigationEnabled}"
-                    Command="{Binding ToggleTabsCommand}" 
-                    BorderThickness="0"
-                    Background="Transparent">
-
-                <StackPanel Orientation="Horizontal" 
-                            Background="Transparent"
-                             Spacing="0">
-                    <Svg Path="/Assets/Icons/drawer-handle.svg"
-                         Margin="0,0,0,0"  />
-                    <Svg Path="{Binding SvgPath}"
-                         Width="10"
-                         Margin="0,0,0,0"
-                         HorizontalAlignment="Left"
-                         />
-                </StackPanel>
-            </Button>
+            <!-- Side panel divider line -->
+            <Border Grid.Column="1" Width="8" Background="#4C61D8"
+                    VerticalAlignment="Stretch"
+                    HorizontalAlignment="Center"
+                    Cursor="Hand"
+                    PointerPressed="OnDrawerLinePressed" />
             
             <!-- Tab Content -->
             <ContentControl Grid.Column="2" 

--- a/Companion/Views/MainView.axaml
+++ b/Companion/Views/MainView.axaml
@@ -18,13 +18,13 @@
     </UserControl.Resources>
     
     <!-- Main Layout -->
-    <Grid Background="{DynamicResource ContentBackground}">
+    <Grid x:Name="MainGrid" Background="{DynamicResource ContentBackground}">
         <!-- Define Rows -->
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" /> <!-- Header -->
             <RowDefinition Height="*" />   <!-- Tab Content -->
             <RowDefinition Height="Auto" MinHeight="5" /> <!-- GridSplitter -->
-            <RowDefinition Height="60" MinHeight="60" /> <!-- Log Viewer with default height -->
+            <RowDefinition Height="60" MinHeight="20" /> <!-- Log Viewer -->
         </Grid.RowDefinitions>
         
         <!-- Header -->
@@ -100,49 +100,74 @@
         </Grid>
         
         <!-- GridSplitter -->
-        <GridSplitter Grid.Row="2"
+        <GridSplitter x:Name="LogSplitter"
+                      Grid.Row="2"
                       Background="{DynamicResource SplitterBackground}"
                       ResizeDirection="Rows"
                       ResizeBehavior="PreviousAndNext"
                       HorizontalAlignment="Stretch"
                       VerticalAlignment="Stretch"
-                      Cursor="SizeNorthSouth" />
+                      Cursor="SizeNorthSouth"
+                      IsVisible="{Binding !IsLogPanelCollapsed}" />
 
         <!-- Log Viewer Section -->
-        <Grid Grid.Row="3" Background="{DynamicResource LogAreaBackground}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="20" MinWidth="20" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            
-            <!-- Log Label and Explorer Link -->
-            <StackPanel Grid.Column="0" Margin="5,3,5,3" VerticalAlignment="Top" >
-                <!-- Vertical "LOG" text -->
-                <!-- <StackPanel Orientation="Vertical" Margin="0,0,0,10" HorizontalAlignment="Center"> -->
-                <!--     <TextBlock Text="L" FontWeight="Bold" FontSize="14" HorizontalAlignment="Center" /> -->
-                <!--     <TextBlock Text="O" FontWeight="Bold" FontSize="14" HorizontalAlignment="Center" /> -->
-                <!--     <TextBlock Text="G" FontWeight="Bold" FontSize="14" HorizontalAlignment="Center" /> -->
-                <!-- </StackPanel> -->
-    
-                <Button Command="{Binding OpenLogFolderCommand}" 
-                        Background="Transparent" 
-                        Padding="0"
-                        BorderThickness="0"
-                        ToolTip.Tip="Open log folder in system file explorer">
-                    <!-- <StackPanel Orientation="Horizontal" Spacing="5"> -->
-                    <!--     <Svg Path="/Assets/Icons/folder-open.svg" Width="16" Height="16" /> -->
-                    <!--     ~1~ <TextBlock Text="Open Folder" /> @1@ -->
-                    <!-- </StackPanel> -->
-                    <StackPanel Orientation="Vertical" Margin="0,0,0,10" HorizontalAlignment="Center">
-                    <TextBlock Text="L" FontWeight="Bold" FontSize="14" HorizontalAlignment="Center"  Foreground="{DynamicResource PrimaryTextForeground}"/>
-                    <TextBlock Text="O" FontWeight="Bold" FontSize="14" HorizontalAlignment="Center" Foreground="{DynamicResource PrimaryTextForeground}"/>
-                    <TextBlock Text="G" FontWeight="Bold" FontSize="14" HorizontalAlignment="Center" Foreground="{DynamicResource PrimaryTextForeground}"/>
-                    </StackPanel>
-                </Button>
-            </StackPanel>
-            
-            <!-- Log Viewer -->
-            <views:LogViewer Grid.Column="1" Margin="3,3,3,3" />
+        <Grid x:Name="LogPanel" Grid.Row="3" Background="{DynamicResource LogAreaBackground}">
+            <!-- Log toggle tab — sticks out above the panel -->
+            <Button x:Name="LogToggleButton"
+                    Command="{Binding ToggleLogPanelCommand}"
+                    Background="{DynamicResource LogAreaBackground}"
+                    Padding="8,2"
+                    BorderThickness="0"
+                    Cursor="Hand"
+                    ToolTip.Tip="Toggle log panel"
+                    HorizontalAlignment="Left"
+                    VerticalAlignment="Top"
+                    Margin="8,-16,0,0"
+                    ZIndex="1">
+                <Button.Styles>
+                    <Style Selector="Button">
+                        <Setter Property="CornerRadius" Value="6,6,0,0" />
+                    </Style>
+                    <Style Selector="Button:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+                        <Setter Property="Background" Value="{DynamicResource LogAreaBackground}" />
+                        <Setter Property="Opacity" Value="0.8" />
+                    </Style>
+                </Button.Styles>
+                <StackPanel Orientation="Horizontal" Spacing="4">
+                    <TextBlock x:Name="LogChevron"
+                               Text="▾"
+                               FontSize="10"
+                               VerticalAlignment="Center"
+                               Foreground="{DynamicResource PrimaryTextForeground}" />
+                    <TextBlock Text="Log"
+                               FontSize="10"
+                               FontWeight="SemiBold"
+                               VerticalAlignment="Center"
+                               Foreground="{DynamicResource PrimaryTextForeground}" />
+                </StackPanel>
+            </Button>
+
+            <!-- Open log folder — top right -->
+            <Button Command="{Binding OpenLogFolderCommand}"
+                    Background="Transparent"
+                    Padding="2,1"
+                    BorderThickness="0"
+                    Cursor="Hand"
+                    IsVisible="{Binding !IsLogPanelCollapsed}"
+                    ToolTip.Tip="Open log folder"
+                    HorizontalAlignment="Right"
+                    VerticalAlignment="Top"
+                    Margin="0,2,8,0"
+                    ZIndex="1">
+                <Path Data="M20 5h-8.5L9.86 2.38A1.91 1.91 0 0 0 8.27 2H4a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2zm0 13H4V4h4l1.79 3H20v11z"
+                      Fill="{DynamicResource PrimaryTextForeground}"
+                      Width="11" Height="11"
+                      Stretch="Uniform" />
+            </Button>
+
+            <!-- Log content -->
+            <views:LogViewer Margin="3,2,3,3"
+                             IsVisible="{Binding !IsLogPanelCollapsed}" />
         </Grid>
     </Grid>
 </UserControl>

--- a/Companion/Views/MainView.axaml.cs
+++ b/Companion/Views/MainView.axaml.cs
@@ -1,5 +1,9 @@
+using System;
+using System.ComponentModel;
 using System.Linq;
+using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Input;
 using Microsoft.Extensions.DependencyInjection;
 using Companion.Events;
 using Companion.Services;
@@ -9,19 +13,41 @@ namespace Companion.Views;
 
 public partial class MainView : UserControl
 {
+    private const double MaxLogPanelRatio = 0.4;
+    private const double MinExpandedHeight = 80; // header bar + 3 log lines
+    private const double CollapsedHeight = 20;
+    private MainViewModel? _viewModel;
+
+    private RowDefinition LogRow
+    {
+        get
+        {
+            var mainGrid = this.FindControl<Grid>("MainGrid");
+            return mainGrid!.RowDefinitions[3];
+        }
+    }
+
     public MainView()
     {
         InitializeComponent();
 
         if (!Design.IsDesignMode)
         {
-            // Resolve MainViewModel from the DI container
-            DataContext = App.ServiceProvider.GetRequiredService<MainViewModel>();
+            _viewModel = App.ServiceProvider.GetRequiredService<MainViewModel>();
+            DataContext = _viewModel;
 
-            // Subscribe to TabSelectionChangeEvent
-            var _eventSubscriptionService = App.ServiceProvider.GetRequiredService<IEventSubscriptionService>();
+            var eventSubscriptionService = App.ServiceProvider.GetRequiredService<IEventSubscriptionService>();
+            eventSubscriptionService.Subscribe<TabSelectionChangeEvent, string>(OnTabSelectionChanged);
 
-            _eventSubscriptionService.Subscribe<TabSelectionChangeEvent, string>(OnTabSelectionChanged);
+            // Set initial log panel height from preferences
+            ApplyLogPanelHeight();
+            UpdateChevron();
+
+            // Track collapse/expand changes
+            _viewModel.PropertyChanged += OnViewModelPropertyChanged;
+
+            LogSplitter.DragDelta += OnSplitterDragDelta;
+            LogSplitter.DragCompleted += OnSplitterDragCompleted;
         }
     }
 
@@ -35,5 +61,67 @@ public partial class MainView : UserControl
             .FirstOrDefault(tab => tab.TabName == selectedTab);
 
         if (targetTab != null) tabControl.SelectedItem = targetTab;
+    }
+
+    private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(MainViewModel.IsLogPanelCollapsed))
+        {
+            ApplyLogPanelHeight();
+            UpdateChevron();
+        }
+    }
+
+    private void ApplyLogPanelHeight()
+    {
+        if (_viewModel == null) return;
+
+        var logRow = LogRow;
+        if (_viewModel.IsLogPanelCollapsed)
+        {
+            logRow.MinHeight = CollapsedHeight;
+            logRow.Height = new GridLength(CollapsedHeight, GridUnitType.Pixel);
+        }
+        else
+        {
+            logRow.MinHeight = MinExpandedHeight;
+            var height = Math.Max(MinExpandedHeight, _viewModel.LogPanelHeight);
+            logRow.Height = new GridLength(height, GridUnitType.Pixel);
+        }
+    }
+
+    private void UpdateChevron()
+    {
+        if (_viewModel != null)
+            LogChevron.Text = _viewModel.IsLogPanelCollapsed ? "▸" : "▾";
+    }
+
+    private void OnSplitterDragDelta(object? sender, VectorEventArgs e)
+    {
+        // e.Vector.Y < 0 means dragging up = making log panel bigger
+        if (e.Vector.Y >= 0) return;
+
+        var mainGrid = LogPanel.Parent as Grid;
+        if (mainGrid == null) return;
+
+        var logRow = LogRow;
+        var maxHeight = mainGrid.Bounds.Height * MaxLogPanelRatio;
+        if (logRow.ActualHeight > maxHeight)
+            logRow.Height = new GridLength(maxHeight, GridUnitType.Pixel);
+    }
+
+    private void OnSplitterDragCompleted(object? sender, VectorEventArgs e)
+    {
+        if (_viewModel == null || _viewModel.IsLogPanelCollapsed) return;
+
+        var mainGrid = LogPanel.Parent as Grid;
+        if (mainGrid == null) return;
+
+        var logRow = LogRow;
+        var maxHeight = mainGrid.Bounds.Height * MaxLogPanelRatio;
+        var height = Math.Min(logRow.ActualHeight, maxHeight);
+        height = Math.Max(height, MinExpandedHeight);
+
+        _viewModel.LogPanelHeight = height;
     }
 }

--- a/Companion/Views/MainView.axaml.cs
+++ b/Companion/Views/MainView.axaml.cs
@@ -124,4 +124,9 @@ public partial class MainView : UserControl
 
         _viewModel.LogPanelHeight = height;
     }
+
+    private void OnDrawerLinePressed(object? sender, PointerPressedEventArgs e)
+    {
+        _viewModel?.ToggleTabsCommand.Execute(null);
+    }
 }


### PR DESCRIPTION
## Summary
- Log panel can be collapsed/expanded via a toggle tab with chevron indicator
- Log panel height is persisted in user preferences, capped at 40% of window, with a 3-line minimum
- Folder icon in log header adapts to color theme
- Side panel divider simplified to a clean border line, triangle arrow removed
- Collapsed sidebar narrowed from 80px to 60px

## Types of changes
-   [x] ⚙️ Tech (code style improvement, performance improvement or dependencies bump)

## Checklist
-   [x] My code follows the code style of this project.
-   [x] I have tested the change locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)