### PR TITLE
Add startup splash and defer startup tab loading

### DIFF
--- a/Companion/App.axaml.cs
+++ b/Companion/App.axaml.cs
@@ -10,6 +10,7 @@ using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Data.Core.Plugins;
 using Avalonia.Markup.Xaml;
 using Avalonia.Styling;
+using Avalonia.Threading;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using MsBox.Avalonia;
@@ -28,6 +29,8 @@ namespace Companion;
 
 public class App : Application
 {
+    private static readonly TimeSpan SplashDisplayThreshold = TimeSpan.FromMilliseconds(200);
+
     public static IServiceProvider ServiceProvider { get; private set; }
 
     public static string OSType { get; private set; }
@@ -219,50 +222,133 @@ public class App : Application
 
     public override void OnFrameworkInitializationCompleted()
     {
-        // Step 1: Load configuration
-        var configuration = LoadConfiguration();
+        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            // Remove Avalonia's default data validation plugin to avoid conflicts
+            BindingPlugins.DataValidators.RemoveAt(0);
+            Dispatcher.UIThread.Post(async () => await InitializeDesktopAsync(desktop), DispatcherPriority.Background);
+        }
+        else if (ApplicationLifetime is ISingleViewApplicationLifetime singleViewPlatform)
+        {
+            InitializeServices();
+            singleViewPlatform.MainView = ServiceProvider.GetRequiredService<MainView>();
+        }
 
-        // Step 2: Configure DI container
+        base.OnFrameworkInitializationCompleted();
+    }
+
+    private async Task InitializeDesktopAsync(IClassicDesktopStyleApplicationLifetime desktop)
+    {
+        var startupStopwatch = Stopwatch.StartNew();
+        StartupSplashWindow? splashWindow = null;
+        ILogger? logger = null;
+
+        try
+        {
+            splashWindow = await ShowSplashIfNeededAsync(splashWindow, desktop, startupStopwatch, "Loading configuration...");
+            var configurationStopwatch = Stopwatch.StartNew();
+            var configuration = await Task.Run(LoadConfiguration);
+            var configurationElapsed = configurationStopwatch.Elapsed;
+
+            splashWindow = await ShowSplashIfNeededAsync(splashWindow, desktop, startupStopwatch, "Preparing services...");
+            var servicesStopwatch = Stopwatch.StartNew();
+            await Task.Run(() =>
+            {
+                var serviceCollection = new ServiceCollection();
+                ConfigureServices(serviceCollection, configuration);
+                ServiceProvider = serviceCollection.BuildServiceProvider();
+            });
+            var servicesElapsed = servicesStopwatch.Elapsed;
+
+            Log.Logger = ServiceProvider.GetRequiredService<ILogger>();
+            logger = Log.ForContext<App>();
+
+            logger.Information(
+                "**********************************************************************************************");
+            logger.Information($"Starting up log for OpenIPC Companion {VersionHelper.GetAppVersion()}");
+            logger.Information("Logger initialized successfully.");
+            logger.Information("Starting up....");
+            logger.Information("Startup timing: configuration loaded in {ElapsedMs} ms.", configurationElapsed.TotalMilliseconds);
+            logger.Information("Startup timing: services built in {ElapsedMs} ms.", servicesElapsed.TotalMilliseconds);
+
+            splashWindow = await ShowSplashIfNeededAsync(splashWindow, desktop, startupStopwatch, "Applying preferences...");
+            var settingsStopwatch = Stopwatch.StartNew();
+            var savedSettings = await Task.Run(SettingsManager.LoadSettings);
+            RequestedThemeVariant = savedSettings?.IsDarkTheme == true
+                ? ThemeVariant.Dark
+                : ThemeVariant.Light;
+            logger.Information("Startup timing: settings applied in {ElapsedMs} ms.", settingsStopwatch.Elapsed.TotalMilliseconds);
+
+            splashWindow = await ShowSplashIfNeededAsync(splashWindow, desktop, startupStopwatch, "Opening window...");
+            var mainWindowStopwatch = Stopwatch.StartNew();
+            var mainWindow = ServiceProvider.GetRequiredService<MainWindow>();
+            logger.Information("Startup timing: MainWindow resolved in {ElapsedMs} ms.", mainWindowStopwatch.Elapsed.TotalMilliseconds);
+            desktop.MainWindow = mainWindow;
+            mainWindow.Show();
+            splashWindow?.Close();
+            logger.Information("Startup timing: main window created in {ElapsedMs} ms.", mainWindowStopwatch.Elapsed.TotalMilliseconds);
+
+            var preferencesService = ServiceProvider.GetRequiredService<IPreferencesService>();
+            if (ShouldCheckForUpdates(preferencesService))
+                _ = CheckForUpdatesAsync();
+
+            logger.Information("Startup timing: total desktop startup completed in {ElapsedMs} ms.", startupStopwatch.Elapsed.TotalMilliseconds);
+        }
+        catch (Exception ex)
+        {
+            logger?.Error(ex, "Desktop startup failed.");
+            splashWindow?.Close();
+            throw;
+        }
+    }
+
+    private static async Task<StartupSplashWindow?> ShowSplashIfNeededAsync(StartupSplashWindow? splashWindow,
+        IClassicDesktopStyleApplicationLifetime desktop, Stopwatch startupStopwatch, string statusText)
+    {
+        if (splashWindow is null && startupStopwatch.Elapsed >= SplashDisplayThreshold)
+        {
+            splashWindow = new StartupSplashWindow
+            {
+                StatusText = statusText
+            };
+            desktop.MainWindow = splashWindow;
+            splashWindow.Show();
+            await Task.Yield();
+            return splashWindow;
+        }
+
+        if (splashWindow is not null)
+        {
+            splashWindow.StatusText = statusText;
+            await Task.Yield();
+        }
+
+        return splashWindow;
+    }
+
+    private void InitializeServices()
+    {
+        var configuration = LoadConfiguration();
         var serviceCollection = new ServiceCollection();
         ConfigureServices(serviceCollection, configuration);
         ServiceProvider = serviceCollection.BuildServiceProvider();
 
-        // Step 3: Initialize logger (resolve it from service provider)
         Log.Logger = ServiceProvider.GetRequiredService<ILogger>();
         var logger = Log.ForContext<App>();
-        
         logger.Information(
             "**********************************************************************************************");
         logger.Information($"Starting up log for OpenIPC Companion {VersionHelper.GetAppVersion()}");
         logger.Information("Logger initialized successfully.");
         logger.Information("Starting up....");
 
-        // check for updates
         var preferencesService = ServiceProvider.GetRequiredService<IPreferencesService>();
         if (ShouldCheckForUpdates(preferencesService))
-            CheckForUpdatesAsync();
+            _ = CheckForUpdatesAsync();
 
-        // Apply saved theme before creating window to prevent flash
         var savedSettings = SettingsManager.LoadSettings();
         RequestedThemeVariant = savedSettings?.IsDarkTheme == true
             ? ThemeVariant.Dark
             : ThemeVariant.Light;
-
-        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
-        {
-            // Remove Avalonia's default data validation plugin to avoid conflicts
-            BindingPlugins.DataValidators.RemoveAt(0);
-
-            // Resolve MainWindow and its DataContext from DI container
-            desktop.MainWindow = ServiceProvider.GetRequiredService<MainWindow>();
-        }
-        else if (ApplicationLifetime is ISingleViewApplicationLifetime singleViewPlatform)
-        {
-            // Resolve MainView and its DataContext from DI container
-            singleViewPlatform.MainView = ServiceProvider.GetRequiredService<MainView>();
-        }
-
-        base.OnFrameworkInitializationCompleted();
     }
 
     private string GetConfigPath()
@@ -386,6 +472,7 @@ public class App : Application
     {
         // Register Views
         services.AddTransient<MainWindow>();
+        services.AddTransient<StartupSplashWindow>();
         services.AddTransient<MainView>();
         services.AddTransient<CameraSettingsTabView>();
         services.AddTransient<ConnectControlsView>();

--- a/Companion/ViewModels/MainViewModel.cs
+++ b/Companion/ViewModels/MainViewModel.cs
@@ -74,11 +74,15 @@ public partial class MainViewModel : ViewModelBase
         IMessageBoxService messageBoxService)
         : base(logger, sshClientService, eventSubscriptionService)
     {
+        var startupStopwatch = Stopwatch.StartNew();
         
         _logger = logger?.ForContext(GetType()) ?? 
                  throw new ArgumentNullException(nameof(logger));
         _messageBoxService = messageBoxService;
+        var loadSettingsStopwatch = Stopwatch.StartNew();
         LoadSettings();
+        _logger.Information("Startup timing: MainViewModel.LoadSettings completed in {ElapsedMs} ms.",
+            loadSettingsStopwatch.Elapsed.TotalMilliseconds);
         
         // Initialize the ping service
         _pingService = PingService.Instance(_logger);
@@ -125,9 +129,17 @@ public partial class MainViewModel : ViewModelBase
         IsVRXEnabled = false;
         
         // initialize tabs with Camera
+        var initializeTabsStopwatch = Stopwatch.StartNew();
         InitializeTabs(DeviceType.Camera);
+        _logger.Information("Startup timing: MainViewModel.InitializeTabs completed in {ElapsedMs} ms.",
+            initializeTabsStopwatch.Elapsed.TotalMilliseconds);
+        var restoreSelectedTabStopwatch = Stopwatch.StartNew();
         RestoreSelectedTab();
+        _logger.Information("Startup timing: MainViewModel.RestoreSelectedTab completed in {ElapsedMs} ms.",
+            restoreSelectedTabStopwatch.Elapsed.TotalMilliseconds);
         _preferencesInitialized = true;
+        _logger.Information("Startup timing: MainViewModel constructor completed in {ElapsedMs} ms.",
+            startupStopwatch.Elapsed.TotalMilliseconds);
     }
 
     private void InitializeTabs(DeviceType deviceType)
@@ -147,18 +159,18 @@ public partial class MainViewModel : ViewModelBase
             if (!_userPreferences.FirmwareFocusedMode)
             {
                 Tabs.Add(new TabItemViewModel("WFB", "avares://Companion/Assets/Icons/iconoir_wifi_dark.svg",
-                    _serviceProvider.GetRequiredService<WfbTabViewModel>(), IsTabsCollapsed));
+                    () => _serviceProvider.GetRequiredService<WfbTabViewModel>(), IsTabsCollapsed));
                 Tabs.Add(new TabItemViewModel("Camera", "avares://Companion/Assets/Icons/iconoir_camera_dark.svg",
-                    _serviceProvider.GetRequiredService<CameraSettingsTabViewModel>(), IsTabsCollapsed));
+                    () => _serviceProvider.GetRequiredService<CameraSettingsTabViewModel>(), IsTabsCollapsed));
                 Tabs.Add(new TabItemViewModel("Telemetry", "avares://Companion/Assets/Icons/iconoir_drag_dark.svg",
-                    _serviceProvider.GetRequiredService<TelemetryTabViewModel>(), IsTabsCollapsed));
+                    () => _serviceProvider.GetRequiredService<TelemetryTabViewModel>(), IsTabsCollapsed));
                 Tabs.Add(new TabItemViewModel("Setup", "avares://Companion/Assets/Icons/iconoir_settings_dark.svg",
-                    _serviceProvider.GetRequiredService<SetupTabViewModel>(), IsTabsCollapsed));
+                    () => _serviceProvider.GetRequiredService<SetupTabViewModel>(), IsTabsCollapsed));
             }
             Tabs.Add(new TabItemViewModel("Firmware", "avares://Companion/Assets/Icons/iconair_firmware_dark.svg",
-                _serviceProvider.GetRequiredService<FirmwareTabViewModel>(), IsTabsCollapsed));
+                () => _serviceProvider.GetRequiredService<FirmwareTabViewModel>(), IsTabsCollapsed));
             Tabs.Add(new TabItemViewModel("Preferences", "avares://Companion/Assets/Icons/iconoir_settings_dark.svg",
-                _serviceProvider.GetRequiredService<PreferencesTabViewModel>(), IsTabsCollapsed));
+                () => _serviceProvider.GetRequiredService<PreferencesTabViewModel>(), IsTabsCollapsed));
         }
         else if (deviceType == DeviceType.Radxa)
         {
@@ -166,12 +178,12 @@ public partial class MainViewModel : ViewModelBase
             {
                 // Need these spaces for some reason
                 Tabs.Add(new TabItemViewModel("WFB         ", "avares://Companion/Assets/Icons/iconoir_wifi_dark.svg",
-                    _serviceProvider.GetRequiredService<WfbGSTabViewModel>(), IsTabsCollapsed));
+                    () => _serviceProvider.GetRequiredService<WfbGSTabViewModel>(), IsTabsCollapsed));
                 Tabs.Add(new TabItemViewModel("Setup", "avares://Companion/Assets/Icons/iconoir_settings_dark.svg",
-                    _serviceProvider.GetRequiredService<SetupTabViewModel>(), IsTabsCollapsed));
+                    () => _serviceProvider.GetRequiredService<SetupTabViewModel>(), IsTabsCollapsed));
             }
             Tabs.Add(new TabItemViewModel("Preferences", "avares://Companion/Assets/Icons/iconoir_settings_dark.svg",
-                _serviceProvider.GetRequiredService<PreferencesTabViewModel>(), IsTabsCollapsed));
+                () => _serviceProvider.GetRequiredService<PreferencesTabViewModel>(), IsTabsCollapsed));
         }
 
         if (Tabs.Count > 0 && (SelectedTab == null || !Tabs.Contains(SelectedTab)))
@@ -1066,17 +1078,14 @@ public partial class MainViewModel : ViewModelBase
         if (Tabs.Count == 0)
             return;
 
-        if (_userPreferences.FirmwareFocusedMode && TrySelectTab("Firmware"))
-            return;
-
         if (!string.IsNullOrWhiteSpace(_userPreferences.LastSelectedTab))
         {
-            if (TrySelectTab(_userPreferences.LastSelectedTab))
+            if (!string.Equals(_userPreferences.LastSelectedTab, "Firmware", StringComparison.OrdinalIgnoreCase)
+                && TrySelectTab(_userPreferences.LastSelectedTab))
                 return;
         }
 
-        SelectedTab = Tabs[0];
-        SelectedTabIndex = 0;
+        SelectDefaultStartupTab();
     }
 
     private bool TrySelectTab(string tabName)
@@ -1090,6 +1099,15 @@ public partial class MainViewModel : ViewModelBase
         SelectedTab = selectedTab;
         SelectedTabIndex = Tabs.IndexOf(selectedTab);
         return true;
+    }
+
+    private void SelectDefaultStartupTab()
+    {
+        var defaultTab = Tabs.FirstOrDefault(tab =>
+            !string.Equals(tab.TabName.Trim(), "Firmware", StringComparison.OrdinalIgnoreCase));
+
+        SelectedTab = defaultTab ?? Tabs[0];
+        SelectedTabIndex = Tabs.IndexOf(SelectedTab);
     }
 
     private void SavePreferences()

--- a/Companion/ViewModels/TabItemViewModel.cs
+++ b/Companion/ViewModels/TabItemViewModel.cs
@@ -7,6 +7,9 @@ namespace Companion.ViewModels;
 /// </summary>
 public class TabItemViewModel
 {
+    private readonly Func<object>? _contentFactory;
+    private object? _content;
+
     #region Public Properties
     /// <summary>
     /// Gets the display name of the tab
@@ -16,7 +19,8 @@ public class TabItemViewModel
     /// <summary>
     /// Gets the content associated with the tab
     /// </summary>
-    public object Content { get; }
+    public object Content => _content ??= _contentFactory?.Invoke()
+        ?? throw new InvalidOperationException($"Tab '{TabName}' does not have content.");
 
     /// <summary>
     /// Gets the icon path/name for the tab (dark variant, for unselected state)
@@ -51,7 +55,20 @@ public class TabItemViewModel
         TabName = tabName ?? throw new ArgumentNullException(nameof(tabName));
         Icon = icon ?? throw new ArgumentNullException(nameof(icon));
         IconLight = icon.Replace("_dark", "_light");
-        Content = content ?? throw new ArgumentNullException(nameof(content));
+        _content = content ?? throw new ArgumentNullException(nameof(content));
+        IsTabsCollapsed = isTabsCollapsed;
+    }
+
+    public TabItemViewModel(
+        string tabName,
+        string icon,
+        Func<object> contentFactory,
+        bool isTabsCollapsed)
+    {
+        TabName = tabName ?? throw new ArgumentNullException(nameof(tabName));
+        Icon = icon ?? throw new ArgumentNullException(nameof(icon));
+        IconLight = icon.Replace("_dark", "_light");
+        _contentFactory = contentFactory ?? throw new ArgumentNullException(nameof(contentFactory));
         IsTabsCollapsed = isTabsCollapsed;
     }
     #endregion

--- a/Companion/Views/MainView.axaml.cs
+++ b/Companion/Views/MainView.axaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Linq;
 using Avalonia;
 using Avalonia.Controls;
@@ -8,6 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Companion.Events;
 using Companion.Services;
 using Companion.ViewModels;
+using Serilog;
 
 namespace Companion.Views;
 
@@ -29,13 +31,20 @@ public partial class MainView : UserControl
 
     public MainView()
     {
+        var stopwatch = Stopwatch.StartNew();
         InitializeComponent();
+        Log.ForContext<MainView>().Information("Startup timing: MainView.InitializeComponent completed in {ElapsedMs} ms.",
+            stopwatch.Elapsed.TotalMilliseconds);
 
         if (!Design.IsDesignMode)
         {
+            var resolveViewModelStopwatch = Stopwatch.StartNew();
             _viewModel = App.ServiceProvider.GetRequiredService<MainViewModel>();
+            Log.ForContext<MainView>().Information("Startup timing: MainViewModel resolved in {ElapsedMs} ms.",
+                resolveViewModelStopwatch.Elapsed.TotalMilliseconds);
             DataContext = _viewModel;
 
+            var subscriptionsStopwatch = Stopwatch.StartNew();
             var eventSubscriptionService = App.ServiceProvider.GetRequiredService<IEventSubscriptionService>();
             eventSubscriptionService.Subscribe<TabSelectionChangeEvent, string>(OnTabSelectionChanged);
 
@@ -48,6 +57,8 @@ public partial class MainView : UserControl
 
             LogSplitter.DragDelta += OnSplitterDragDelta;
             LogSplitter.DragCompleted += OnSplitterDragCompleted;
+            Log.ForContext<MainView>().Information("Startup timing: MainView post-initialize wiring completed in {ElapsedMs} ms.",
+                subscriptionsStopwatch.Elapsed.TotalMilliseconds);
         }
     }
 

--- a/Companion/Views/MainWindow.axaml.cs
+++ b/Companion/Views/MainWindow.axaml.cs
@@ -1,4 +1,6 @@
+using System.Diagnostics;
 using Avalonia.Controls;
+using Serilog;
 
 namespace Companion.Views;
 
@@ -6,6 +8,9 @@ public partial class MainWindow : Window
 {
     public MainWindow()
     {
+        var stopwatch = Stopwatch.StartNew();
         InitializeComponent();
+        Log.ForContext<MainWindow>().Information("Startup timing: MainWindow.InitializeComponent completed in {ElapsedMs} ms.",
+            stopwatch.Elapsed.TotalMilliseconds);
     }
 }

--- a/Companion/Views/StartupSplashWindow.axaml
+++ b/Companion/Views/StartupSplashWindow.axaml
@@ -1,0 +1,41 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:view="using:Companion.Views"
+        x:Class="Companion.Views.StartupSplashWindow"
+        x:DataType="view:StartupSplashWindow"
+        Width="420"
+        Height="240"
+        CanResize="False"
+        ShowInTaskbar="True"
+        SystemDecorations="BorderOnly"
+        WindowStartupLocation="CenterScreen"
+        Title="OpenIPC Companion">
+    <Border Background="{DynamicResource ThemeBackgroundBrush}"
+            Padding="28">
+        <Grid RowDefinitions="Auto,Auto,*">
+            <StackPanel Spacing="12">
+                <Image Source="/Assets/Icons/OpenIPC.png"
+                       Width="64"
+                       Height="64"
+                       HorizontalAlignment="Center" />
+                <TextBlock Text="OpenIPC Companion"
+                           HorizontalAlignment="Center"
+                           FontSize="24"
+                           FontWeight="SemiBold" />
+                <TextBlock Text="{Binding VersionText}"
+                           HorizontalAlignment="Center"
+                           Opacity="0.75" />
+            </StackPanel>
+
+            <StackPanel Grid.Row="2"
+                        VerticalAlignment="Bottom"
+                        Spacing="10">
+                <ProgressBar IsIndeterminate="True"
+                             Height="6" />
+                <TextBlock Text="{Binding StatusText}"
+                           HorizontalAlignment="Center"
+                           Opacity="0.8" />
+            </StackPanel>
+        </Grid>
+    </Border>
+</Window>

--- a/Companion/Views/StartupSplashWindow.axaml.cs
+++ b/Companion/Views/StartupSplashWindow.axaml.cs
@@ -1,0 +1,35 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using Avalonia.Controls;
+
+namespace Companion.Views;
+
+public partial class StartupSplashWindow : Window, INotifyPropertyChanged
+{
+    public string StatusText
+    {
+        get => _statusText;
+        set
+        {
+            _statusText = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public string VersionText { get; } = global::Companion.Services.VersionHelper.GetAppVersion();
+
+    private string _statusText = "Starting...";
+
+    public new event PropertyChangedEventHandler? PropertyChanged;
+
+    public StartupSplashWindow()
+    {
+        InitializeComponent();
+        DataContext = this;
+    }
+
+    private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}


### PR DESCRIPTION
## Summary

- add a lightweight desktop startup splash screen for slow cold starts
- log startup timing for configuration load, service setup, main window creation, and key view/viewmodel initialization steps
- defer tab content creation so tab view models are not all resolved at startup
- prevent the Firmware tab from being auto-selected on app launch before the user connects to a device

## Why

Cold starts on desktop are noticeably slower than warm starts, especially on first launch. The splash screen makes that startup cost feel intentional instead of looking like the app is hung.

The timing logs showed two main issues:
- configuration loading is a meaningful startup cost
- the app was eagerly creating tab content, including the Firmware tab path, during startup

This change adds visibility into startup time and removes unnecessary startup work.

## Behavior Changes

- the splash only appears when startup has already exceeded a short threshold, so it should not flash during fast warm launches
- Firmware is no longer selected during startup just because firmware-focused mode is enabled
- after a successful camera connect, firmware-focused mode still switches to the Firmware tab

## Testing

- ran `dotnet build Companion/Companion.csproj`
- launched locally from Rider and verified the splash appears on slower startup
- checked startup timing logs in `Companion20260409.log`
- confirmed `MainViewModel.InitializeTabs` dropped substantially after lazy tab loading
- confirmed Firmware is no longer intended to be the startup tab before connect
