### PR TITLE
ci: use stable release tag url in latest.json

### DIFF
--- a/.github/workflows/build_and_release_all.yml
+++ b/.github/workflows/build_and_release_all.yml
@@ -499,12 +499,11 @@ jobs:
           set -euo pipefail
 
           RELEASE_BODY="$(gh release view "${GITHUB_REF_NAME}" --repo "${GITHUB_REPOSITORY}" --json body --jq .body)"
-          RELEASE_URL="$(gh release view "${GITHUB_REF_NAME}" --repo "${GITHUB_REPOSITORY}" --json url --jq .url)"
 
           jq -n \
             --arg version "${VERSION}" \
             --arg notes "${RELEASE_BODY}" \
-            --arg url "${RELEASE_URL}" \
+            --arg url "https://github.com/${GITHUB_REPOSITORY}/releases/tag/${GITHUB_REF_NAME}" \
             '{
               version: $version,
               release_notes: $notes,


### PR DESCRIPTION
## Description
This follow-up updates the release workflow so generated latest.json files point to the stable tagged GitHub release URL instead of the transient draft-style release page URL.

## Why
The updater reminder worked, but the download link in latest.json could point to an untagged draft-style release URL immediately after publish. This change makes future releases deterministic.

## How Has This Been Tested
- Verified the workflow diff and syntax with git diff --check
- Replaced the live 0.9.0 latest.json asset manually and confirmed the public updater endpoint behavior

## Types of changes
- [x] ⚙️ Tech (code style improvement, performance improvement or dependencies bump)

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have tested the change locally.
