### PR TITLE
fix: use offline sysupgrade path for uploaded firmware

### DIFF
--- a/Companion/Services/SysUpgradeService.cs
+++ b/Companion/Services/SysUpgradeService.cs
@@ -41,7 +41,7 @@ public class SysUpgradeService
             updateProgress("Starting sysupgrade. Do not unplug the device.");
             await _sshClientService.ExecuteCommandWithProgressAsync(
                 deviceConfig,
-                $"sysupgrade --force_ver -n --kernel={OpenIPC.RemoteTempFolder}/{kernelFilename} --rootfs={OpenIPC.RemoteTempFolder}/{rootfsFilename}",
+                $"sysupgrade --force_ver -n -z --kernel={OpenIPC.RemoteTempFolder}/{kernelFilename} --rootfs={OpenIPC.RemoteTempFolder}/{rootfsFilename}",
                 updateProgress,
                 cancellationToken,
                 timeout: TimeSpan.FromMinutes(15),


### PR DESCRIPTION
## Summary
- add -z to uploaded-image sysupgrade so the device stays on the offline local-file path
- avoid the OpenIPC sysupgrade time-sync/self-update preflight during uploaded firmware upgrades
- preserve the clean reboot/reconnect behavior observed in the retest

## Validation
- verified live upgrade no longer logs `Synchronizing time` or `Checking for sysupgrade update...`
- verified kernel/rootfs flash completed and the device rebooted/reconnected successfully in Companion