### PR TITLE
Refactor log viewer view model binding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -219,6 +219,10 @@ csx/
 ecf/
 rcf/
 
+# Local tooling and generated resources
+\!AvaloniaResources/
+.claude/
+
 # Windows Store app package directories and files
 AppPackages/
 BundleArtifacts/

--- a/Companion/ViewModels/MainViewModel.cs
+++ b/Companion/ViewModels/MainViewModel.cs
@@ -117,6 +117,7 @@ public partial class MainViewModel : ViewModelBase
         
         OpenLogFolderCommand = new RelayCommand(() => OpenLogFolder());
         ToggleLogPanelCommand = new RelayCommand(() => IsLogPanelCollapsed = !IsLogPanelCollapsed);
+        LogViewerViewModel = _serviceProvider.GetRequiredService<LogViewerViewModel>();
 
         // Initialize the path
         UpdateSvgPath();

--- a/Companion/Views/LogViewer.axaml.cs
+++ b/Companion/Views/LogViewer.axaml.cs
@@ -3,7 +3,6 @@ using System.Collections.Specialized;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Threading;
-using Microsoft.Extensions.DependencyInjection;
 using Companion.ViewModels;
 
 namespace Companion.Views;
@@ -23,9 +22,6 @@ public partial class LogViewer : UserControl
         AttachedToVisualTree += (_, _) => ScrollToLatest();
         DetachedFromVisualTree += (_, _) => UnsubscribeFromLogMessages(_currentViewModel);
         SizeChanged += OnSizeChanged;
-
-        //if (!Design.IsDesignMode) DataContext = new LogViewerViewModel();
-        DataContext = App.ServiceProvider.GetService<LogViewerViewModel>();
         OnDataContextChanged(this, EventArgs.Empty);
     }
 

--- a/Companion/Views/MainView.axaml
+++ b/Companion/Views/MainView.axaml
@@ -151,8 +151,11 @@
             </Button>
 
             <!-- Log content -->
-            <views:LogViewer Margin="3,2,3,3"
-                             IsVisible="{Binding !IsLogPanelCollapsed}" />
+            <Border Margin="3,2,3,3"
+                    Background="Transparent"
+                    IsVisible="{Binding !IsLogPanelCollapsed}">
+                <views:LogViewer DataContext="{Binding LogViewerViewModel}" />
+            </Border>
         </Grid>
     </Grid>
 </UserControl>


### PR DESCRIPTION
## Summary
  Fixes the log viewer DataContext wiring so MainView compiled bindings continue to resolve against MainViewModel while LogViewer receives LogViewerViewModel explicitly.