### PR TITLE
Hotfix: merge dev into master for log viewer binding fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -219,6 +219,10 @@ csx/
 ecf/
 rcf/
 
+# Local tooling and generated resources
+\!AvaloniaResources/
+.claude/
+
 # Windows Store app package directories and files
 AppPackages/
 BundleArtifacts/

--- a/Companion/ViewModels/MainViewModel.cs
+++ b/Companion/ViewModels/MainViewModel.cs
@@ -117,6 +117,7 @@ public partial class MainViewModel : ViewModelBase
         
         OpenLogFolderCommand = new RelayCommand(() => OpenLogFolder());
         ToggleLogPanelCommand = new RelayCommand(() => IsLogPanelCollapsed = !IsLogPanelCollapsed);
+        LogViewerViewModel = _serviceProvider.GetRequiredService<LogViewerViewModel>();
 
         // Initialize the path
         UpdateSvgPath();

--- a/Companion/Views/LogViewer.axaml.cs
+++ b/Companion/Views/LogViewer.axaml.cs
@@ -3,7 +3,6 @@ using System.Collections.Specialized;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Threading;
-using Microsoft.Extensions.DependencyInjection;
 using Companion.ViewModels;
 
 namespace Companion.Views;
@@ -23,9 +22,6 @@ public partial class LogViewer : UserControl
         AttachedToVisualTree += (_, _) => ScrollToLatest();
         DetachedFromVisualTree += (_, _) => UnsubscribeFromLogMessages(_currentViewModel);
         SizeChanged += OnSizeChanged;
-
-        //if (!Design.IsDesignMode) DataContext = new LogViewerViewModel();
-        DataContext = App.ServiceProvider.GetService<LogViewerViewModel>();
         OnDataContextChanged(this, EventArgs.Empty);
     }
 

--- a/Companion/Views/MainView.axaml
+++ b/Companion/Views/MainView.axaml
@@ -151,8 +151,11 @@
             </Button>
 
             <!-- Log content -->
-            <views:LogViewer Margin="3,2,3,3"
-                             IsVisible="{Binding !IsLogPanelCollapsed}" />
+            <Border Margin="3,2,3,3"
+                    Background="Transparent"
+                    IsVisible="{Binding !IsLogPanelCollapsed}">
+                <views:LogViewer DataContext="{Binding LogViewerViewModel}" />
+            </Border>
         </Grid>
     </Grid>
 </UserControl>

--- a/docs/0.9.0-to-0.9.1-sysupgrade-hotfix.md
+++ b/docs/0.9.0-to-0.9.1-sysupgrade-hotfix.md
@@ -1,0 +1,111 @@
+# Companion 0.9.0 Issue and 0.9.1 Sysupgrade Hotfix
+
+## Summary
+
+Companion `v0.9.0` shipped with an issue in the uploaded-image firmware upgrade path.
+
+When Companion uploaded `kernel` and `rootfs` files to the device and then ran `sysupgrade`, it used:
+
+```sh
+sysupgrade --force_ver -n --kernel=/tmp/<kernel-file> --rootfs=/tmp/<rootfs-file>
+```
+
+That command was not fully offline on OpenIPC devices. Because it did not include `-z`, the device-side `sysupgrade` script could still:
+
+- synchronize time with `ntpd`
+- check GitHub for an updated `sysupgrade` script
+- add extra delay and state transitions before the real flash started
+
+This was fixed in `v0.9.1` by changing the command to:
+
+```sh
+sysupgrade --force_ver -n -z --kernel=/tmp/<kernel-file> --rootfs=/tmp/<rootfs-file>
+```
+
+`-z` forces the local-file offline path and skips the updater self-update preflight.
+
+## What We Observed
+
+During a failing `v0.9.0` sysupgrade test, Companion logs showed the device going down the online preflight path even though firmware files had already been uploaded locally:
+
+- `Synchronizing time`
+- `Checking for sysupgrade update...`
+- `Version checking failed, proceeding with the installed version.`
+
+After that, the flash progressed into kernel and rootfs update stages, but Companion appeared to hang during the rootfs phase and did not complete the normal reboot/reconnect flow.
+
+Companion logs also showed the rootfs erase appearing to stall early in one run.
+
+We left the device alone for roughly 15 to 20 minutes while it appeared stuck before the `flashcp` and `sysupgrade` processes finally disappeared. At that point, the device was still up, reachable, and had not performed a clean reboot yet.
+
+## What We Verified
+
+We gathered device-side evidence over SSH while the upgrade was in progress and after it appeared stuck.
+
+### The device was not bricked
+
+After the hung-looking run:
+
+- the device still accepted SSH connections
+- root filesystem and overlay mounts were healthy
+- the running system reported a coherent March 7, 2026 build
+
+### The flash contents were valid
+
+We compared the uploaded files in `/tmp` against the flash partitions on the device:
+
+- `/tmp/uImage.ssc338q` matched `/dev/mtdblock2`
+- `/tmp/rootfs.squashfs.ssc338q` matched `/dev/mtdblock3`
+
+That ruled out the main concern that `mtd3` had been partially erased or corrupted in a damaging way.
+
+### The previous run had not rebooted cleanly
+
+Before manual reboot:
+
+- device uptime had not reset
+- the device was still running a normal userspace
+- mounts were normal
+
+This strongly suggested that the flash had completed, but the expected reboot transition had not completed cleanly from Companion's point of view.
+
+## Working Hypothesis
+
+The most likely sequence in `v0.9.0` was:
+
+1. Companion launched uploaded-image `sysupgrade` without `-z`.
+2. OpenIPC `sysupgrade` entered its online preflight path.
+3. That extra preflight added timing and state changes that were not needed for a local-file flash.
+4. The actual flash still completed successfully.
+5. Companion then got stuck around the reboot/reconnect boundary, even though the flashed image on the device was valid.
+
+The evidence does not support a bad image write as the primary issue.
+
+## Fix in 0.9.1
+
+The fix was to add `-z` in `Companion/Services/SysUpgradeService.cs` so uploaded-image sysupgrade stays on the offline local-file path.
+
+Commit:
+
+- `54a4ceb` `fix: use offline sysupgrade path for uploaded firmware`
+
+## Retest Result
+
+After applying the `-z` fix and retesting with the same upgrade path:
+
+- the old `Synchronizing time` / `Checking for sysupgrade update...` lines were gone
+- kernel flash completed normally
+- rootfs flash progressed past the earlier failure point
+- overlay erase completed
+- the device rebooted cleanly
+- Companion observed the full recovery sequence:
+  - device offline
+  - ping recovered
+  - SSH recovered
+  - firmware upgrade completed successfully
+
+## Conclusion
+
+`v0.9.0` had a real sysupgrade-path bug, but the failure mode was primarily upgrade orchestration and timing, not a broken flash image.
+
+`v0.9.1` corrected the command path and resolved the observed issue in live validation.


### PR DESCRIPTION
## Summary
Promotes the latest hotfixes from dev to master.

This includes:
- the log viewer DataContext binding fix that resolves the InvalidCastException involving MainViewModel and LogViewerViewModel
- the 0.9.1 sysupgrade hotfix investigation documentation

## Notes
The docs change is already effectively present on master in content, but this PR syncs branch history and brings master fully back in line with dev.

## Testing
- verified the log viewer debug-time binding exception no longer reproduces