### PR TITLE
Use non-single-file macOS release packaging

### DIFF
--- a/.github/workflows/build_and_release_all.yml
+++ b/.github/workflows/build_and_release_all.yml
@@ -108,7 +108,7 @@ jobs:
           elif [[ "${{ runner.os }}" == "macOS" ]]; then
             dotnet publish Companion.Desktop/Companion.Desktop.csproj \
               -c Release -r osx-${{ matrix.arch }} --self-contained true \
-              -p:PublishSingleFile=true -p:UseAppHost=true
+              -p:PublishSingleFile=false -p:PublishReadyToRun=true -p:UseAppHost=true
           else
             dotnet publish Companion.Desktop/Companion.Desktop.csproj \
               -c Release -r linux-${{ matrix.arch }} --self-contained true \
@@ -248,7 +248,9 @@ jobs:
 
           rm -rf "$APP_DIR"
           mkdir -p "${APP_DIR}/Contents/MacOS" "${APP_DIR}/Contents/Resources"
-          cp -R "${PUBLISH_DIR}/"* "${APP_DIR}/Contents/MacOS/"
+          # Copy the full publish output into the bundle instead of relying on
+          # single-file extraction at app startup.
+          ditto "$PUBLISH_DIR" "${APP_DIR}/Contents/MacOS"
           [[ -f "$ICON_SRC" ]] && cp "$ICON_SRC" "${APP_DIR}/Contents/Resources/OpenIPC.icns" || true
 
           if [[ -f "${APP_DIR}/Contents/MacOS/Companion.Desktop" ]]; then


### PR DESCRIPTION
## Summary
Switch macOS release builds in GitHub Actions from self-contained single-file packaging to a standard self-contained app bundle.

## Why
Bug report #183 shows a macOS user hitting:

Failed to create CoreCLR, HRESULT: 0x80070008

The current release workflow packages macOS as a single-file apphost inside the app bundle. This PR changes the macOS release artifact to bundle the full publish output instead, including the runtimeconfig, deps file, managed assemblies, and native .NET runtime libraries. That removes the single-file CoreCLR extraction/startup path from the shipped macOS app.

## Validation
- Built and published a test artifact from this branch via GitHub Actions.
- Downloaded the macOS DMG and verified that Companion.app Contents MacOS now contains the full .NET publish output rather than the previous sparse single-file layout.

Closes #183