### PR TITLE
Promote dev to master for macOS release packaging fix

### DIFF
--- a/.github/workflows/build_and_release_all.yml
+++ b/.github/workflows/build_and_release_all.yml
@@ -108,7 +108,7 @@ jobs:
           elif [[ "${{ runner.os }}" == "macOS" ]]; then
             dotnet publish Companion.Desktop/Companion.Desktop.csproj \
               -c Release -r osx-${{ matrix.arch }} --self-contained true \
-              -p:PublishSingleFile=true -p:UseAppHost=true
+              -p:PublishSingleFile=false -p:PublishReadyToRun=true -p:UseAppHost=true
           else
             dotnet publish Companion.Desktop/Companion.Desktop.csproj \
               -c Release -r linux-${{ matrix.arch }} --self-contained true \
@@ -248,7 +248,9 @@ jobs:
 
           rm -rf "$APP_DIR"
           mkdir -p "${APP_DIR}/Contents/MacOS" "${APP_DIR}/Contents/Resources"
-          cp -R "${PUBLISH_DIR}/"* "${APP_DIR}/Contents/MacOS/"
+          # Copy the full publish output into the bundle instead of relying on
+          # single-file extraction at app startup.
+          ditto "$PUBLISH_DIR" "${APP_DIR}/Contents/MacOS"
           [[ -f "$ICON_SRC" ]] && cp "$ICON_SRC" "${APP_DIR}/Contents/Resources/OpenIPC.icns" || true
 
           if [[ -f "${APP_DIR}/Contents/MacOS/Companion.Desktop" ]]; then


### PR DESCRIPTION
## Summary
Promote the current dev branch to master to release the macOS packaging change that avoids single-file CoreCLR startup in the shipped app bundle.

## Included fix
- Use non-single-file self-contained packaging for macOS release artifacts in GitHub Actions.
- Bundle the full .NET publish output inside Companion.app Contents MacOS.

## Context
This promotes the change originally introduced to address the macOS startup failure reported in #183:
Failed to create CoreCLR, HRESULT: 0x80070008

Dev already contains the fix and the branch artifact was verified to contain the expected non-single-file app layout.

Refs #183