### PR TITLE
Fix macOS signed app startup by adding .NET entitlements

### DIFF
--- a/.github/workflows/build_and_release_all.yml
+++ b/.github/workflows/build_and_release_all.yml
@@ -238,6 +238,7 @@ jobs:
 
           # NOTE: project paths changed — icons now live under Companion.Desktop
           ICON_SRC="./Companion/Assets/Icons/OpenIPC.icns"
+          ENTITLEMENTS_PATH="./Companion.Desktop/Entitlements.plist"
 
           PUBLISH_DIR="./Companion.Desktop/bin/Release/net8.0/osx-${{ matrix.arch }}/publish"
           APP_DIR="${APP_NAME}.app"
@@ -283,6 +284,7 @@ jobs:
             echo "Signing app with identity: $CODESIGN_IDENTITY"
             codesign --keychain "$KEYCHAIN_PATH" \
                      --deep --force --verify --verbose \
+                     --entitlements "$ENTITLEMENTS_PATH" \
                      --options runtime \
                      --timestamp \
                      --sign "${CODESIGN_IDENTITY}" "${APP_DIR}"

--- a/Companion.Desktop/Entitlements.plist
+++ b/Companion.Desktop/Entitlements.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+</dict>
+</plist>


### PR DESCRIPTION
Summary:
Fix macOS app startup for signed and notarized releases by adding the standard .NET host entitlements during codesigning.

Why:
Signed macOS releases starting in 0.9.0 could fail at launch with Failed to create CoreCLR, HRESULT: 0x80070008.
The regression was reproduced in a macOS VM, and a dev build with the entitlements applied starts correctly.

Changes:
- add Companion.Desktop/Entitlements.plist
- pass that entitlements file to the macOS codesign step in the release workflow

Validation:
- 0.8.1 works in VM
- 0.9.0 fails in VM
- updated dev build with entitlements works in VM