### PR TITLE
Fix Linux log folder path

### DIFF
--- a/Companion/ViewModels/MainViewModel.cs
+++ b/Companion/ViewModels/MainViewModel.cs
@@ -1151,8 +1151,8 @@ public partial class MainViewModel : ViewModelBase
         }
         else if (OperatingSystem.IsLinux())
         {
-            appDataFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".config");
-            logPath = Path.Combine(appDataFolder, appName, "logs");
+            appDataFolder = OpenIPC.AppDataConfigDirectory;
+            logPath = Path.Combine(appDataFolder, "Logs");
         }
         else
         {


### PR DESCRIPTION
## Summary
- fix the Linux log-folder opener to use the shared app data directory
- align the opened folder with the existing Linux log/config path logic
- leave macOS and Windows behavior unchanged

## Testing
- not run (code path inspection only)