### PR TITLE
Align build-them with GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ dotnet build Companion.Desktop/Companion.Desktop.csproj -c Release
 dotnet run --project Companion.Desktop/Companion.Desktop.csproj
 ```
 
+For local cross-platform packaging checks, use `./build-them.sh`. That script is intended for developer testing before pushing changes. GitHub Actions is the source of truth for official CI builds, release artifacts, and published releases.
+
 ## Documentation
 
 - [Configuration and logging](docs/configuration.md)

--- a/build-them.sh
+++ b/build-them.sh
@@ -1,14 +1,19 @@
 #!/bin/bash
 set -euo pipefail
 
+# Local developer packaging helper only.
+# Use this to validate cross-platform build outputs before pushing changes.
+# GitHub Actions remains the source of truth for CI builds, release artifacts, and published releases.
+
 desktop_project="Companion.Desktop/Companion.Desktop.csproj"
 tests_project="Companion.Tests/Companion.Tests.csproj"
-
+app_name="Companion"
 output_root="build"
 publish_root="$output_root/publish"
 package_root="$output_root/packages"
 verbosity="minimal"
 run_tests_flag=true
+release_version=""
 
 build_all=false
 build_macos=false
@@ -17,13 +22,15 @@ build_linux=false
 
 usage() {
     cat <<EOF
-Usage: $0 [all|macos|windows|linux] [-v verbosity] [--skip-tests]
+Usage: $0 [all|macos|windows|linux ...] [-v verbosity] [--skip-tests]
 
-Builds desktop publish outputs and archives them for local testing.
+Builds desktop publish outputs for local developer testing and packages them to match GitHub Actions as closely as possible.
+GitHub Actions is still the source of truth for official build and release artifacts.
 
 Examples:
+  $0
   $0 linux
-  $0 windows -v normal
+  $0 windows macos -v normal
   $0 all --skip-tests
 EOF
 }
@@ -35,6 +42,23 @@ ensure_command() {
     fi
 }
 
+derive_release_version() {
+    local head_tag
+    head_tag="$(git tag --points-at HEAD | grep -E '^(release-v|v)' | head -n 1 || true)"
+
+    if [[ -n "$head_tag" ]]; then
+        if [[ "$head_tag" == release-v* ]]; then
+            release_version="${head_tag#release-v}"
+        elif [[ "$head_tag" == v* ]]; then
+            release_version="${head_tag#v}"
+        fi
+    fi
+
+    if [[ -z "$release_version" ]]; then
+        release_version="0.0.0-dev+$(git rev-parse --short HEAD)"
+    fi
+}
+
 clean_outputs() {
     echo "Cleaning previous desktop outputs..."
     rm -rf "$output_root"
@@ -42,14 +66,53 @@ clean_outputs() {
     dotnet clean "$desktop_project" >/dev/null
 }
 
+restore_dependencies() {
+    echo "Restoring desktop project..."
+    dotnet restore "$desktop_project" -v "$verbosity"
+}
+
+restore_for_publish() {
+    local rid="$1"
+    local os_family="$2"
+
+    echo "Restoring desktop project for $rid..."
+    if [[ "$os_family" == "windows" ]]; then
+        dotnet restore "$desktop_project" \
+            -r "$rid" \
+            -p:PublishReadyToRun=true \
+            -v "$verbosity"
+    else
+        dotnet restore "$desktop_project" \
+            -r "$rid" \
+            -v "$verbosity"
+    fi
+}
+
+build_desktop() {
+    echo "Building desktop project..."
+    dotnet build "$desktop_project" \
+        --configuration Release \
+        --no-restore \
+        -v "$verbosity"
+}
+
 run_tests() {
-    if [ "$run_tests_flag" != true ]; then
+    if [[ "$run_tests_flag" != true ]]; then
         echo "Skipping tests."
         return
     fi
 
     echo "Running desktop test suite..."
-    dotnet test "$tests_project" --logger "trx;LogFileName=TestResults.xml"
+    dotnet test "$tests_project" \
+        --configuration Release \
+        --logger "trx;LogFileName=TestResults.xml" \
+        -v "$verbosity"
+}
+
+write_version_file() {
+    local publish_dir="$1"
+    mkdir -p "$publish_dir"
+    printf 'v%s\n' "$release_version" > "$publish_dir/VERSION"
 }
 
 archive_directory() {
@@ -68,34 +131,32 @@ archive_directory() {
     )
 }
 
-publish_desktop() {
-    local rid="$1"
-    local publish_dir="$publish_root/$rid"
-
-    echo "Publishing $rid..."
-    dotnet publish "$desktop_project" \
-        -c Release \
-        -r "$rid" \
-        --self-contained true \
-        --output "$publish_dir" \
-        -p:PublishSingleFile=true \
-        -v "$verbosity"
-}
-
-package_linux() {
+publish_linux() {
     local arch="$1"
     local rid="linux-$arch"
     local publish_dir="$publish_root/$rid"
     local package_dir="$package_root/Companion-linux-$arch"
     local archive_path="$package_root/Companion-linux-$arch.zip"
 
-    publish_desktop "$rid"
+    echo "Publishing $rid..."
+    rm -rf "$publish_dir" "$package_dir"
+    restore_for_publish "$rid" "linux"
 
-    rm -rf "$package_dir"
+    dotnet publish "$desktop_project" \
+        -c Release \
+        -r "$rid" \
+        --self-contained true \
+        --output "$publish_dir" \
+        --no-restore \
+        -p:PublishSingleFile=true \
+        -v "$verbosity"
+
+    write_version_file "$publish_dir"
+
     mkdir -p "$package_dir"
     cp -R "$publish_dir"/. "$package_dir"/
 
-    if [ -f "$package_dir/Companion.Desktop" ]; then
+    if [[ -f "$package_dir/Companion.Desktop" ]]; then
         mv "$package_dir/Companion.Desktop" "$package_dir/Companion.DesktopApp"
         chmod +x "$package_dir/Companion.DesktopApp"
     fi
@@ -104,17 +165,32 @@ package_linux() {
     echo "Created $archive_path"
 }
 
-package_windows() {
+publish_windows() {
     local arch="$1"
     local rid="win-$arch"
+    local publish_dir="$publish_root/$rid"
     local package_dir="$package_root/Companion-windows-$arch"
     local archive_path="$package_root/Companion-windows-$arch.zip"
 
-    publish_desktop "$rid"
+    echo "Publishing $rid..."
+    rm -rf "$publish_dir" "$package_dir"
+    restore_for_publish "$rid" "windows"
 
-    rm -rf "$package_dir"
+    dotnet publish "$desktop_project" \
+        -c Release \
+        -r "$rid" \
+        --self-contained true \
+        --output "$publish_dir" \
+        --no-restore \
+        -p:PublishSingleFile=false \
+        -p:PublishReadyToRun=true \
+        -p:IncludeNativeLibrariesForSelfExtract=true \
+        -v "$verbosity"
+
+    write_version_file "$publish_dir"
+
     mkdir -p "$package_dir"
-    cp -R "$publish_root/$rid"/. "$package_dir"/
+    cp -R "$publish_dir"/. "$package_dir"/
 
     archive_directory "$archive_path" "$package_dir"
     echo "Created $archive_path"
@@ -127,10 +203,14 @@ create_macos_app_bundle() {
     rm -rf "$app_dir"
     mkdir -p "$app_dir/Contents/MacOS" "$app_dir/Contents/Resources"
 
-    cp -R "$publish_dir"/. "$app_dir/Contents/MacOS"/
-    cp "Companion/Assets/Icons/OpenIPC.icns" "$app_dir/Contents/Resources/Companion.icns"
+    if command -v ditto >/dev/null 2>&1; then
+        ditto "$publish_dir" "$app_dir/Contents/MacOS"
+    else
+        cp -R "$publish_dir"/. "$app_dir/Contents/MacOS"/
+    fi
+    [[ -f "Companion/Assets/Icons/OpenIPC.icns" ]] && cp "Companion/Assets/Icons/OpenIPC.icns" "$app_dir/Contents/Resources/OpenIPC.icns"
 
-    if [ -f "$app_dir/Contents/MacOS/Companion.Desktop" ]; then
+    if [[ -f "$app_dir/Contents/MacOS/Companion.Desktop" ]]; then
         chmod +x "$app_dir/Contents/MacOS/Companion.Desktop"
     fi
 
@@ -140,49 +220,98 @@ create_macos_app_bundle() {
 <plist version="1.0">
 <dict>
     <key>CFBundleName</key>
-    <string>Companion</string>
+    <string>${app_name}</string>
     <key>CFBundleDisplayName</key>
-    <string>Companion</string>
+    <string>${app_name}</string>
     <key>CFBundleExecutable</key>
     <string>Companion.Desktop</string>
     <key>CFBundleIdentifier</key>
-    <string>com.openipc.Companion</string>
+    <string>org.openipc.Companion</string>
     <key>CFBundleVersion</key>
-    <string>1.0</string>
+    <string>${release_version}</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.0</string>
+    <string>${release_version}</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>LSMinimumSystemVersion</key>
     <string>13.0</string>
     <key>CFBundleIconFile</key>
-    <string>Companion.icns</string>
+    <string>OpenIPC.icns</string>
 </dict>
 </plist>
 EOF
 }
 
-package_macos() {
-    local rid="osx-arm64"
-    local publish_dir="$publish_root/$rid"
-    local package_dir="$package_root/Companion-macos-arm64"
+package_macos_dmg() {
+    local package_dir="$1"
+    local dmg_path="$2"
     local app_dir="$package_dir/Companion.app"
-    local archive_path="$package_root/Companion-macos-arm64.zip"
 
-    publish_desktop "$rid"
+    rm -f "$dmg_path"
+    rm -rf "$package_dir/dmg_build"
+    mkdir -p "$package_dir/dmg_build"
 
-    rm -rf "$package_dir"
+    if command -v ditto >/dev/null 2>&1; then
+        ditto "$app_dir" "$package_dir/dmg_build/Companion.app"
+    else
+        cp -R "$app_dir" "$package_dir/dmg_build/Companion.app"
+    fi
+    ln -s /Applications "$package_dir/dmg_build/Applications"
+
+    hdiutil create \
+        -volname "Companion" \
+        -srcfolder "$package_dir/dmg_build" \
+        -ov \
+        -format UDZO \
+        -fs HFS+ \
+        "$dmg_path" >/dev/null
+
+    rm -rf "$package_dir/dmg_build"
+}
+
+publish_macos() {
+    local arch="$1"
+    local rid="osx-$arch"
+    local publish_dir="$publish_root/$rid"
+    local package_dir="$package_root/Companion-macos-$arch"
+    local app_dir="$package_dir/Companion.app"
+    local dmg_path="$package_root/Companion-macos-$arch.dmg"
+    local zip_path="$package_root/Companion-macos-$arch.zip"
+
+    echo "Publishing $rid..."
+    rm -rf "$publish_dir" "$package_dir"
+    rm -f "$dmg_path" "$zip_path"
+    restore_for_publish "$rid" "macos"
+
+    dotnet publish "$desktop_project" \
+        -c Release \
+        -r "$rid" \
+        --self-contained true \
+        --output "$publish_dir" \
+        --no-restore \
+        -p:PublishSingleFile=false \
+        -p:PublishReadyToRun=true \
+        -p:UseAppHost=true \
+        -v "$verbosity"
+
+    write_version_file "$publish_dir"
     mkdir -p "$package_dir"
     create_macos_app_bundle "$publish_dir" "$app_dir"
 
-    archive_directory "$archive_path" "$package_dir"
-    echo "Created $archive_path"
+    if command -v hdiutil >/dev/null 2>&1; then
+        package_macos_dmg "$package_dir" "$dmg_path"
+        echo "Created $dmg_path"
+    else
+        archive_directory "$zip_path" "$package_dir"
+        echo "Created $zip_path"
+        echo "hdiutil not available; packaged macOS app as zip instead of dmg."
+    fi
 }
 
 parse_args() {
-    if [ $# -eq 0 ]; then
-        usage
-        exit 1
+    if [[ $# -eq 0 ]]; then
+        build_all=true
+        return
     fi
 
     while [[ $# -gt 0 ]]; do
@@ -204,7 +333,7 @@ parse_args() {
                 ;;
             -v|--verbosity)
                 shift
-                if [ $# -eq 0 ]; then
+                if [[ $# -eq 0 ]]; then
                     echo "Missing verbosity value."
                     exit 1
                 fi
@@ -222,31 +351,41 @@ parse_args() {
         esac
         shift
     done
+
+    if [[ "$build_all" != true && "$build_macos" != true && "$build_windows" != true && "$build_linux" != true ]]; then
+        build_all=true
+    fi
 }
 
 main() {
     ensure_command dotnet
     ensure_command zip
+    ensure_command git
 
     parse_args "$@"
+    derive_release_version
     clean_outputs
+    restore_dependencies
+    build_desktop
     run_tests
 
-    if [ "$build_all" = true ] || [ "$build_linux" = true ]; then
-        package_linux "arm64"
-        package_linux "x64"
+    if [[ "$build_all" = true || "$build_linux" = true ]]; then
+        publish_linux "x64"
+        publish_linux "arm64"
     fi
 
-    if [ "$build_all" = true ] || [ "$build_windows" = true ]; then
-        package_windows "arm64"
-        package_windows "x64"
+    if [[ "$build_all" = true || "$build_windows" = true ]]; then
+        publish_windows "x64"
+        publish_windows "arm64"
     fi
 
-    if [ "$build_all" = true ] || [ "$build_macos" = true ]; then
-        package_macos
+    if [[ "$build_all" = true || "$build_macos" = true ]]; then
+        publish_macos "x64"
+        publish_macos "arm64"
     fi
 
     echo
+    echo "Release version: v$release_version"
     echo "Desktop publish outputs: $publish_root"
     echo "Packaged artifacts: $package_root"
 }


### PR DESCRIPTION
Summary:
- update build-them.sh to behave more like the GitHub Actions desktop build flow
- keep local developer options for building all targets, specific targets, and skipping tests
- document that build-them.sh is for local validation while GitHub Actions remains the source of truth for official builds and releases

Testing:
- bash -n build-them.sh
- ./build-them.sh --help
- ./build-them.sh --skip-tests (confirmed target selection fix and Linux packaging flow; local restore later failed on NuGet/network during Windows cross-target restore)