### PR TITLE
Normalize Avalonia 11 package versions

### DIFF
--- a/Companion.Android/Companion.Android.csproj
+++ b/Companion.Android/Companion.Android.csproj
@@ -33,8 +33,8 @@
 
     <ItemGroup>
         <PackageReference Include="Avalonia.Android" Version="$(AvaloniaVersion)"/>
-        <PackageReference Include="Avalonia.Svg.Skia" Version="11.2.0.2"/>
-        <PackageReference Include="Avalonia.Xaml.Interactivity" Version="11.2.0.12" />
+        <PackageReference Include="Avalonia.Svg.Skia" Version="$(AvaloniaSvgSkiaVersion)"/>
+        <PackageReference Include="Avalonia.Xaml.Interactivity" Version="$(AvaloniaXamlInteractivityVersion)" />
         <PackageReference Include="MessageBox.Avalonia" Version="3.2.0"/>
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.2" />
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0-rc.2.24473.5"/>

--- a/Companion.Desktop/Companion.Desktop.csproj
+++ b/Companion.Desktop/Companion.Desktop.csproj
@@ -36,8 +36,8 @@
         <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)"/>
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
         <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)"/>
-        <PackageReference Include="Avalonia.Svg.Skia" Version="11.2.0.2"/>
-        <PackageReference Include="Avalonia.Xaml.Interactivity" Version="11.2.0.12" />
+        <PackageReference Include="Avalonia.Svg.Skia" Version="$(AvaloniaSvgSkiaVersion)"/>
+        <PackageReference Include="Avalonia.Xaml.Interactivity" Version="$(AvaloniaXamlInteractivityVersion)" />
         <PackageReference Include="MessageBox.Avalonia" Version="3.2.0"/>
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.2" />
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0-rc.2.24473.5"/>

--- a/Companion.Desktop/Companion.Desktop.csproj
+++ b/Companion.Desktop/Companion.Desktop.csproj
@@ -36,9 +36,9 @@
         <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)"/>
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
         <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)"/>
-        <PackageReference Include="Avalonia.Svg.Skia" Version="$(AvaloniaSvgSkiaVersion)"/>
         <PackageReference Include="Avalonia.Xaml.Interactivity" Version="$(AvaloniaXamlInteractivityVersion)" />
         <PackageReference Include="MessageBox.Avalonia" Version="3.2.0"/>
+        <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="$(SkiaSharpNativeAssetsLinuxVersion)" />
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.2" />
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0-rc.2.24473.5"/>
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0-rc.2.24473.5"/>

--- a/Companion.Tests/Companion.Tests.csproj
+++ b/Companion.Tests/Companion.Tests.csproj
@@ -10,9 +10,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia.Desktop" Version="0.10.13"/>
-        <PackageReference Include="Avalonia.Svg.Skia" Version="11.2.0.2"/>
-        <PackageReference Include="Avalonia.Xaml.Interactivity" Version="11.2.0.12" />
+        <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)"/>
+        <PackageReference Include="Avalonia.Svg.Skia" Version="$(AvaloniaSvgSkiaVersion)"/>
+        <PackageReference Include="Avalonia.Xaml.Interactivity" Version="$(AvaloniaXamlInteractivityVersion)" />
         <PackageReference Include="coverlet.collector" Version="6.0.4"/>
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.2" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0"/>

--- a/Companion.iOS/Companion.iOS.csproj
+++ b/Companion.iOS/Companion.iOS.csproj
@@ -43,8 +43,8 @@
 
     <ItemGroup>
         <PackageReference Include="Avalonia.iOS" Version="$(AvaloniaVersion)"/>
-        <PackageReference Include="Avalonia.Svg.Skia" Version="11.2.0.2"/>
-        <PackageReference Include="Avalonia.Xaml.Interactivity" Version="11.2.0.12" />
+        <PackageReference Include="Avalonia.Svg.Skia" Version="$(AvaloniaSvgSkiaVersion)"/>
+        <PackageReference Include="Avalonia.Xaml.Interactivity" Version="$(AvaloniaXamlInteractivityVersion)" />
         <PackageReference Include="MessageBox.Avalonia" Version="3.2.0"/>
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.2" />
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0-rc.2.24473.5"/>

--- a/Companion/App.axaml.cs
+++ b/Companion/App.axaml.cs
@@ -390,11 +390,10 @@ public class App : Application
 
     public virtual async Task ShowUpdateDialogAsync(string releaseNotes, string downloadUrl, string newVersion)
     {
-        var msgBox = MessageBoxManager.GetMessageBoxStandard("Update Available",
+        var messageBoxService = ServiceProvider.GetRequiredService<IMessageBoxService>();
+        var result = await messageBoxService.ShowCustomMessageBox("Update Available",
             $"New version available: {newVersion}\n\n{releaseNotes}\n\nDo you want to download the update?",
             ButtonEnum.YesNo);
-
-        var result = await msgBox.ShowAsync();
 
         if (result == ButtonResult.Yes) OpenBrowser(downloadUrl);
     }

--- a/Companion/Companion.csproj
+++ b/Companion/Companion.csproj
@@ -56,12 +56,12 @@
 
     <ItemGroup>
         <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)"/>
-        <PackageReference Include="Avalonia.Svg.Skia" Version="11.2.0.2"/>
+        <PackageReference Include="Avalonia.Svg.Skia" Version="$(AvaloniaSvgSkiaVersion)"/>
         <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)"/>
         <PackageReference Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)"/>
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
         <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)"/>
-        <PackageReference Include="Avalonia.Xaml.Interactivity" Version="11.2.0.12" />
+        <PackageReference Include="Avalonia.Xaml.Interactivity" Version="$(AvaloniaXamlInteractivityVersion)" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1"/>
         <PackageReference Include="MessageBox.Avalonia" Version="3.2.0"/>
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.2" />

--- a/Companion/Services/MessageBoxService.cs
+++ b/Companion/Services/MessageBoxService.cs
@@ -7,9 +7,9 @@ using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
-using MsBox.Avalonia;
 using MsBox.Avalonia.Enums;
 using Companion.Services;
+using Companion.Views;
 using Serilog;
 
 namespace Companion.Services;
@@ -25,29 +25,17 @@ namespace Companion.Services;
         
         public async Task ShowMessageBox(string title, string message, Window? owner = null, Icon icon = Icon.Info)
         {
-            var msgBox = MessageBoxManager.GetMessageBoxStandard(
-                title,
-                message,
-                ButtonEnum.Ok,
-                icon,
-                WindowStartupLocation.CenterScreen
-            );
-
-            await ShowMessageBoxAsync(msgBox, owner);
+            owner ??= ResolveOwnerWindow();
+            await ShowSimpleDialogAsync(title, message, ButtonEnum.Ok, owner);
         }
         
         public async Task<ButtonResult> ShowMessageBoxWithFolderLink(string title, string message, string filePath, Window? owner = null)
         {
-            // For folder operations, we'll use a custom approach instead
-            var msgBox = MessageBoxManager.GetMessageBoxStandard(
+            var result = await ShowSimpleDialogAsync(
                 title,
                 message + "\n\nWould you like to open the containing folder?",
                 ButtonEnum.YesNo,
-                Icon.Info,
-                WindowStartupLocation.CenterScreen
-            );
-
-            var result = await ShowMessageBoxAsync(msgBox, owner);
+                owner);
             
             if (result == ButtonResult.Yes)
             {
@@ -104,23 +92,20 @@ namespace Companion.Services;
         // A more flexible version that accepts standard button configurations
         public async Task<ButtonResult> ShowCustomMessageBox(string title, string message, ButtonEnum buttons, Icon icon = Icon.Info, Window? owner = null)
         {
-            var msgBox = MessageBoxManager.GetMessageBoxStandard(
-                title,
-                message,
-                buttons,
-                icon,
-                WindowStartupLocation.CenterScreen
-            );
-
-            return await ShowMessageBoxAsync(msgBox, owner);
+            return await ShowSimpleDialogAsync(title, message, buttons, owner);
         }
 
-        private static async Task<ButtonResult> ShowMessageBoxAsync(dynamic msgBox, Window? owner = null)
+        private static async Task<ButtonResult> ShowSimpleDialogAsync(string title, string message, ButtonEnum buttons,
+            Window? owner = null)
         {
             owner ??= ResolveOwnerWindow();
-            return owner != null
-                ? await msgBox.ShowWindowDialogAsync(owner)
-                : await msgBox.ShowAsync();
+            var dialog = new SimpleMessageDialog(title, message, buttons);
+
+            if (owner is not null)
+                return await dialog.ShowDialog<ButtonResult>(owner);
+
+            dialog.Show();
+            return ButtonResult.None;
         }
 
         private static Window? ResolveOwnerWindow()

--- a/Companion/Services/SshClientService.cs
+++ b/Companion/Services/SshClientService.cs
@@ -15,15 +15,17 @@ namespace Companion.Services;
 public class SshClientService : ISshClientService
 {
     private IEventSubscriptionService _eventSubscriptionService;
+    private readonly IMessageBoxService _messageBoxService;
 
     private readonly ILogger _logger;
 
-    public SshClientService(IEventSubscriptionService eventSubscriptionService, ILogger logger)
+    public SshClientService(IEventSubscriptionService eventSubscriptionService, ILogger logger, IMessageBoxService messageBoxService)
     {
         _logger = logger?.ForContext(GetType()) ?? 
                   throw new ArgumentNullException(nameof(logger));
         
         _eventSubscriptionService = eventSubscriptionService;
+        _messageBoxService = messageBoxService;
     }
 
     public async Task<SshCommand> ExecuteCommandWithResponseAsync(DeviceConfig deviceConfig, string command,
@@ -327,8 +329,7 @@ public class SshClientService : ISshClientService
         }
         else
         {
-            var msgBox = MessageBoxManager.GetMessageBoxStandard("Error", $"File {fileName} not found.");
-            msgBox.ShowAsync();
+            await _messageBoxService.ShowMessageBox("Error", $"File {fileName} not found.");
         }
     }
 

--- a/Companion/ViewModels/ConnectControlsViewModel.cs
+++ b/Companion/ViewModels/ConnectControlsViewModel.cs
@@ -35,6 +35,7 @@ public partial class ConnectControlsViewModel : ViewModelBase
     private readonly Ping _ping = new();
     private readonly TimeSpan _pingInterval = TimeSpan.FromSeconds(1);
     private readonly TimeSpan _pingTimeout = TimeSpan.FromMilliseconds(500);
+    private readonly IMessageBoxService _messageBoxService;
     private bool _canConnect;
     private DeviceConfig _deviceConfig;
     private SolidColorBrush _pingStatusColor = new(Colors.Red);
@@ -121,9 +122,11 @@ public partial class ConnectControlsViewModel : ViewModelBase
     public ConnectControlsViewModel(ILogger logger,
         ISshClientService sshClientService,
         IEventSubscriptionService eventSubscriptionService,
-        IGlobalSettingsService globalSettingsService)
+        IGlobalSettingsService globalSettingsService,
+        IMessageBoxService messageBoxService)
         : base(logger, sshClientService, eventSubscriptionService)
     {
+        _messageBoxService = messageBoxService;
         SetDefaults();
         LoadSettings();
 
@@ -537,10 +540,9 @@ public partial class ConnectControlsViewModel : ViewModelBase
 
         if (cmdResult == null)
         {
-            var resp = MessageBoxManager.GetMessageBoxStandard(
+            await _messageBoxService.ShowMessageBox(
                 "Timeout Error!",
                 "The command took too long to execute. Please check device..");
-            await resp.ShowAsync();
             return;
         }
 

--- a/Companion/ViewModels/MainViewModel.cs
+++ b/Companion/ViewModels/MainViewModel.cs
@@ -559,11 +559,9 @@ public partial class MainViewModel : ViewModelBase
         if (!validator.IsDeviceConfigValid(_deviceConfig))
         {
             UpdateUIMessage("Hostname Error!");
-            var msBox = MessageBoxManager.GetMessageBoxStandard("Hostname Error!",
+            var result = await _messageBoxService.ShowCustomMessageBox("Hostname Error!",
                 $"Hostname does not match device type! \nHostname: {_deviceConfig.Hostname} Device Type: {_selectedDeviceType}.\nPlease check device..\nOk to continue anyway\nCancel to quit",
                 ButtonEnum.OkCancel);
-
-            var result = await msBox.ShowAsync();
             if (result == ButtonResult.Cancel)
             {
                 _logger.Debug("Device selection and hostname mismatch, stopping");
@@ -655,9 +653,8 @@ public partial class MainViewModel : ViewModelBase
         {
             // Handle the timeout
             // .
-            var resp = MessageBoxManager.GetMessageBoxStandard("Timeout Error!",
+            await _messageBoxService.ShowMessageBox("Timeout Error!",
                 "The command took too long to execute. Please check device..");
-            await resp.ShowAsync();
             return;
         }
 
@@ -694,9 +691,8 @@ public partial class MainViewModel : ViewModelBase
         {
             // Handle the timeout
             // .
-            var resp = MessageBoxManager.GetMessageBoxStandard("Timeout Error!",
+            await _messageBoxService.ShowMessageBox("Timeout Error!",
                 "The command took too long to execute. Please check device..");
-            await resp.ShowAsync();
             return;
         }
 
@@ -732,9 +728,8 @@ public partial class MainViewModel : ViewModelBase
         {
             // Handle the timeout
             // .
-            var resp = MessageBoxManager.GetMessageBoxStandard("Timeout Error!",
+            await _messageBoxService.ShowMessageBox("Timeout Error!",
                 "The command took too long to execute. Please check device..");
-            await resp.ShowAsync();
             return;
         }
 
@@ -770,9 +765,8 @@ public partial class MainViewModel : ViewModelBase
         {
             // Handle the timeout
             // .
-            var resp = MessageBoxManager.GetMessageBoxStandard("Timeout Error!",
+            await _messageBoxService.ShowMessageBox("Timeout Error!",
                 "The command took too long to execute. Please check device..");
-            await resp.ShowAsync();
             return;
         }
 
@@ -900,7 +894,7 @@ public partial class MainViewModel : ViewModelBase
 
         _logger.Information("Done reading files from device.");
 
-        _messageBoxService.ShowMessageBox("Read Device", "Done reading from device!", icon: Icon.None);
+        await _messageBoxService.ShowMessageBox("Read Device", "Done reading from device!", icon: Icon.None);
 
     }
 
@@ -956,8 +950,7 @@ public partial class MainViewModel : ViewModelBase
             }
             else
             {
-                await MessageBoxManager.GetMessageBoxStandard("Error", "Failed to download /etc/wifibroadcast.cfg")
-                    .ShowAsync();
+                await _messageBoxService.ShowMessageBox("Error", "Failed to download /etc/wifibroadcast.cfg");
             }
         }
         catch (Exception e)

--- a/Companion/ViewModels/PresetsTabViewModel.cs
+++ b/Companion/ViewModels/PresetsTabViewModel.cs
@@ -33,6 +33,7 @@ public partial class PresetsTabViewModel : ViewModelBase
     private readonly IPresetService _presetService;
     private readonly HttpClient _httpClient;
     private readonly ILogger _logger;
+    private readonly IMessageBoxService _messageBoxService;
     private readonly bool _presetsEnabled;
 
     #region Observable Properties
@@ -96,7 +97,8 @@ public partial class PresetsTabViewModel : ViewModelBase
         ISshClientService sshClientService,
         IEventSubscriptionService eventSubscriptionService,
         IGitHubPresetService gitHubPresetService,
-        IPresetService presetService)
+        IPresetService presetService,
+        IMessageBoxService messageBoxService)
         : base(logger, sshClientService, eventSubscriptionService)
     {
         _gitHubPresetService = gitHubPresetService;
@@ -104,6 +106,7 @@ public partial class PresetsTabViewModel : ViewModelBase
         _logger = logger?.ForContext(GetType()) ?? 
                  throw new ArgumentNullException(nameof(logger));
         _httpClient = new HttpClient();
+        _messageBoxService = messageBoxService;
         _presetsEnabled = IsPresetsEnabled();
 
         SubscribeToEvents();
@@ -659,9 +662,9 @@ public partial class PresetsTabViewModel : ViewModelBase
                 // Show a success message to the user
                 await Dispatcher.UIThread.InvokeAsync(async () =>
                 {
-                    await MessageBoxManager.GetMessageBoxStandard(
+                    await _messageBoxService.ShowMessageBox(
                         "Success",
-                        $"Successfully applied preset '{preset.Name}'").ShowAsync();
+                        $"Successfully applied preset '{preset.Name}'");
                 });
             }
             else
@@ -673,9 +676,9 @@ public partial class PresetsTabViewModel : ViewModelBase
                 // Show an error message to the user
                 await Dispatcher.UIThread.InvokeAsync(async () =>
                 {
-                    await MessageBoxManager.GetMessageBoxStandard(
+                    await _messageBoxService.ShowMessageBox(
                         "Error",
-                        $"Failed to apply preset '{preset.Name}'. Check the log for details.").ShowAsync();
+                        $"Failed to apply preset '{preset.Name}'. Check the log for details.");
                 });
             }
         }
@@ -688,9 +691,9 @@ public partial class PresetsTabViewModel : ViewModelBase
             // Show an error message to the user
             await Dispatcher.UIThread.InvokeAsync(async () =>
             {
-                await MessageBoxManager.GetMessageBoxStandard(
+                await _messageBoxService.ShowMessageBox(
                     "Error",
-                    $"Error applying preset: {ex.Message}").ShowAsync();
+                    $"Error applying preset: {ex.Message}");
             });
         }
         finally

--- a/Companion/ViewModels/SetupTabViewModel.cs
+++ b/Companion/ViewModels/SetupTabViewModel.cs
@@ -339,11 +339,9 @@ private async Task ExecuteKeyManagementActionAsync()
     {
         if (!CanConnect)
         {
-            var msgBox = MessageBoxManager.GetMessageBoxStandard(
-                "Connection Required", 
-                "Please connect to a device before performing key management actions.",
-                ButtonEnum.Ok);
-            await msgBox.ShowAsync();
+            await _messageBoxService.ShowMessageBox(
+                "Connection Required",
+                "Please connect to a device before performing key management actions.");
             return;
         }
         
@@ -377,11 +375,9 @@ private async Task ExecuteKeyManagementActionAsync()
         Logger.Error(ex, "Error in key management");
         UpdateUIMessage($"Error: {ex.Message}");
         
-        var msgBox = MessageBoxManager.GetMessageBoxStandard(
-            "Error", 
-            $"An error occurred during key management: {ex.Message}",
-            ButtonEnum.Ok);
-        await msgBox.ShowAsync();
+        await _messageBoxService.ShowMessageBox(
+            "Error",
+            $"An error occurred during key management: {ex.Message}");
     }
 }
 
@@ -437,18 +433,15 @@ private async Task GenerateNewKeyAsync()
         KeyValidationColor = Brushes.Green;
         KeyValidationMessage = "New key generated successfully";
         
-        var msgBox = MessageBoxManager.GetMessageBoxStandard(
-            "Key Generated", 
-            $"New encryption key generated and saved to:\n{_localKeyPath}\n\nChecksum: {checksum}",
-            ButtonEnum.Ok);
-        await msgBox.ShowAsync();
+        await _messageBoxService.ShowMessageBox(
+            "Key Generated",
+            $"New encryption key generated and saved to:\n{_localKeyPath}\n\nChecksum: {checksum}");
         
         // Ask if user wants to upload the key to the device
-        var uploadMsg = MessageBoxManager.GetMessageBoxStandard(
+        var result = await _messageBoxService.ShowCustomMessageBox(
             "Upload Key", 
             "Do you want to upload this key to the connected device?",
             ButtonEnum.YesNo);
-        var result = await uploadMsg.ShowAsync();
         
         if (result == ButtonResult.Yes)
         {
@@ -556,11 +549,9 @@ private async Task UploadKeyAsync(string specificKeyPath = null)
             KeyValidationColor = Brushes.Red;
             KeyValidationMessage = "Key upload failed verification";
             
-            var msgBox = MessageBoxManager.GetMessageBoxStandard(
-                "Verification Failed", 
-                "The uploaded key could not be verified. Checksums do not match.",
-                ButtonEnum.Ok);
-            await msgBox.ShowAsync();
+            await _messageBoxService.ShowMessageBox(
+                "Verification Failed",
+                "The uploaded key could not be verified. Checksums do not match.");
         }
     }
     catch (Exception ex)
@@ -596,12 +587,11 @@ private async Task DownloadKeyFromDeviceAsync()
         if (File.Exists(droneKeyPath))
         {
             Logger.Debug("drone.key already exists locally, checking if user wants to overwrite");
-            var msgBox = MessageBoxManager.GetMessageBoxStandard(
+            var result = await _messageBoxService.ShowCustomMessageBox(
                 "File Exists", 
                 "A drone.key file already exists locally. Do you want to overwrite it?",
                 ButtonEnum.YesNo);
-            
-            var result = await msgBox.ShowAsync();
+
             if (result == ButtonResult.No)
             {
                 Logger.Debug("User chose not to overwrite existing drone.key");
@@ -660,11 +650,9 @@ private async Task DownloadKeyFromDeviceAsync()
             KeyValidationColor = Brushes.Red;
             KeyValidationMessage = "Key download failed";
             
-            var msgBox = MessageBoxManager.GetMessageBoxStandard(
-                "Download Failed", 
-                "Failed to download key from device.",
-                ButtonEnum.Ok);
-            await msgBox.ShowAsync();
+            await _messageBoxService.ShowMessageBox(
+                "Download Failed",
+                "Failed to download key from device.");
         }
     }
     catch (Exception ex)
@@ -722,11 +710,9 @@ private async Task VerifyKeyAsync()
                 KeyValidationColor = Brushes.Green;
                 KeyValidationMessage = "Key verified successfully";
                 
-                var msgBox = MessageBoxManager.GetMessageBoxStandard(
-                    "Verification Success", 
-                    "The device key matches the local key.\nChecksum: " + deviceChecksum,
-                    ButtonEnum.Ok);
-                await msgBox.ShowAsync();
+                await _messageBoxService.ShowMessageBox(
+                    "Verification Success",
+                    "The device key matches the local key.\nChecksum: " + deviceChecksum);
             }
             else
             {
@@ -735,12 +721,10 @@ private async Task VerifyKeyAsync()
                 KeyValidationColor = Brushes.Red;
                 KeyValidationMessage = "Key verification failed - checksums don't match";
                 
-                var msgBox = MessageBoxManager.GetMessageBoxStandard(
-                    "Verification Failed", 
+                await _messageBoxService.ShowMessageBox(
+                    "Verification Failed",
                     "The device key does not match the local key.\n\n" +
-                    $"Local: {localChecksum}\nDevice: {deviceChecksum}",
-                    ButtonEnum.Ok);
-                await msgBox.ShowAsync();
+                    $"Local: {localChecksum}\nDevice: {deviceChecksum}");
             }
         }
         else
@@ -751,14 +735,13 @@ private async Task VerifyKeyAsync()
             KeyValidationColor = Brushes.Yellow;
             KeyValidationMessage = "No local key to compare with";
             
-            var msgBox = MessageBoxManager.GetMessageBoxStandard(
+            var result = await _messageBoxService.ShowCustomMessageBox(
                 "No Local Key", 
                 "No local key file found to compare with the device key.\n\n" +
                 $"Device key checksum: {deviceChecksum}\n\n" +
                 "Would you like to download the key from the device?",
                 ButtonEnum.YesNo);
-            
-            var result = await msgBox.ShowAsync();
+
             if (result == ButtonResult.Yes)
             {
                 await DownloadKeyFromDeviceAsync();
@@ -905,11 +888,7 @@ private string CalculateChecksum(byte[] data)
         var selectedSensor = SelectedSensor;
         if (selectedSensor == null)
         {
-            MessageBoxManager.GetMessageBoxStandard("Error", "No sensor selected");
-
-            var box = MessageBoxManager
-                .GetMessageBoxStandard("error!", "No sensor selected!");
-            await box.ShowAsync();
+            await _messageBoxService.ShowMessageBox("Error", "No sensor selected!");
             return;
         }
 
@@ -960,20 +939,19 @@ private string CalculateChecksum(byte[] data)
         var hosts = BuildScanTargets(ScanIpLabel);
         if (hosts.Count == 0)
         {
-            var invalidBox = MessageBoxManager.GetMessageBoxStandard("Invalid subnet",
+            await _messageBoxService.ShowMessageBox("Invalid subnet",
                 "Enter a valid prefix like 192.168., 192.168.1., or a full IP.");
-            await invalidBox.ShowAsync();
             IsScanning = false;
             return;
         }
 
         if (hosts.Count > 4096)
         {
-            var confirm = MessageBoxManager.GetMessageBoxStandard(
+            var result = await _messageBoxService.ShowCustomMessageBox(
                 "Large scan",
                 $"This will scan {hosts.Count} addresses and may take a while. Continue?",
                 ButtonEnum.YesNo);
-            if (await confirm.ShowAsync() != ButtonResult.Yes)
+            if (result != ButtonResult.Yes)
             {
                 IsScanning = false;
                 return;
@@ -1035,8 +1013,7 @@ private string CalculateChecksum(byte[] data)
         else
         {
             ScanMessages = "Scan completed";
-            var confirmBox = MessageBoxManager.GetMessageBoxStandard("Scan completed", "Scan completed");
-            await confirmBox.ShowAsync();
+            await _messageBoxService.ShowMessageBox("Scan completed", "Scan completed");
         }
 
         IsScanning = false;
@@ -1338,10 +1315,8 @@ private string CalculateChecksum(byte[] data)
 
             // Step 5: Execute sysupgrade
 
-            var msgBox = MessageBoxManager.GetMessageBoxStandard("Confirm",
+            var result = await _messageBoxService.ShowCustomMessageBox("Confirm",
                 $"This will download and update your camera to {SelectedFwVersion}, continue?", ButtonEnum.OkAbort);
-
-            var result = await msgBox.ShowAsync();
             if (result == ButtonResult.Abort)
             {
                 Log.Debug("Upgrade Cancelled!");
@@ -1495,10 +1470,8 @@ private string CalculateChecksum(byte[] data)
         if (File.Exists(droneKeyPath))
         {
             Log.Debug("drone.key already exists locally, do you want to overwrite it?");
-            var msBox = MessageBoxManager.GetMessageBoxStandard("File exists!",
+            var result = await _messageBoxService.ShowCustomMessageBox("File exists!",
                 "File drone.key already exists locally, do you want to overwrite it?", ButtonEnum.OkCancel);
-
-            var result = await msBox.ShowAsync();
             if (result == ButtonResult.Cancel)
             {
                 Log.Debug("local drone.key was not overwritten");

--- a/Companion/ViewModels/WfbGSTabViewModel.cs
+++ b/Companion/ViewModels/WfbGSTabViewModel.cs
@@ -62,6 +62,7 @@ public partial class WfbGSTabViewModel : ViewModelBase
 
     private readonly WfbGsConfigParser _wfbGsConfigParser;
     private readonly WifiConfigParser _wifiConfigParser;
+    private readonly IMessageBoxService _messageBoxService;
 
 
     [ObservableProperty] private bool _canConnect;
@@ -78,11 +79,13 @@ public partial class WfbGSTabViewModel : ViewModelBase
 
     public WfbGSTabViewModel(ILogger logger,
         ISshClientService sshClientService,
-        IEventSubscriptionService eventSubscriptionService)
+        IEventSubscriptionService eventSubscriptionService,
+        IMessageBoxService messageBoxService)
         : base(logger, sshClientService, eventSubscriptionService)
     {
         _wfbGsConfigParser = new WfbGsConfigParser();
         _wifiConfigParser = new WifiConfigParser();
+        _messageBoxService = messageBoxService;
 
         InitializeCollections();
 
@@ -125,7 +128,7 @@ public partial class WfbGSTabViewModel : ViewModelBase
         // /etc/modprobe.d/wfb.conf
         await UpdateModprobeWfbConf();
 
-        await MessageBoxManager.GetMessageBoxStandard("Success", "Saved!").ShowAsync();
+        await _messageBoxService.ShowMessageBox("Success", "Saved!");
     }
 
     private async Task UpdateModprobeWfbConf()
@@ -138,7 +141,7 @@ public partial class WfbGSTabViewModel : ViewModelBase
 
             if (string.IsNullOrEmpty(updatedConfigString))
             {
-                await MessageBoxManager.GetMessageBoxStandard("Error", "Updated configuration is empty").ShowAsync();
+                await _messageBoxService.ShowMessageBox("Error", "Updated configuration is empty");
                 return;
             }
 
@@ -172,7 +175,7 @@ public partial class WfbGSTabViewModel : ViewModelBase
 
             if (string.IsNullOrEmpty(updatedConfigContent))
             {
-                await MessageBoxManager.GetMessageBoxStandard("Error", "Updated configuration is empty").ShowAsync();
+                await _messageBoxService.ShowMessageBox("Error", "Updated configuration is empty");
                 return;
             }
 
@@ -184,7 +187,7 @@ public partial class WfbGSTabViewModel : ViewModelBase
         catch (Exception ex)
         {
             Log.Error(ex, "Failed to update configuration file.");
-            await MessageBoxManager.GetMessageBoxStandard("Error", "Failed to update configuration.").ShowAsync();
+            await _messageBoxService.ShowMessageBox("Error", "Failed to update configuration.");
         }
     }
 

--- a/Companion/ViewModels/WfbTabViewModel.cs
+++ b/Companion/ViewModels/WfbTabViewModel.cs
@@ -29,6 +29,7 @@ public partial class WfbTabViewModel : ViewModelBase
     private readonly IYamlConfigService _yamlConfigService;
     private readonly Dictionary<string, string> _yamlConfig = new();
     private readonly IGlobalSettingsService _globalSettingsService;
+    private readonly IMessageBoxService _messageBoxService;
     #endregion
 
     #region Observable Properties
@@ -80,11 +81,13 @@ public partial class WfbTabViewModel : ViewModelBase
         ISshClientService sshClientService,
         IEventSubscriptionService eventSubscriptionService,
         IYamlConfigService yamlConfigService,
-        IGlobalSettingsService globalSettingsSettingsViewModel)
+        IGlobalSettingsService globalSettingsSettingsViewModel,
+        IMessageBoxService messageBoxService)
         : base(logger, sshClientService, eventSubscriptionService)
     {
         _yamlConfigService = yamlConfigService ?? throw new ArgumentNullException(nameof(yamlConfigService));
         _globalSettingsService = globalSettingsSettingsViewModel ?? throw new ArgumentNullException(nameof(globalSettingsSettingsViewModel));
+        _messageBoxService = messageBoxService;
         
         // read device to determine configurations
         _globalSettingsService.ReadDevice();
@@ -259,7 +262,7 @@ public partial class WfbTabViewModel : ViewModelBase
 
         if (string.IsNullOrEmpty(updatedWfbConfContent))
         {
-            await MessageBoxManager.GetMessageBoxStandard("Error", "WfbConfContent is empty").ShowAsync();
+            await _messageBoxService.ShowMessageBox("Error", "WfbConfContent is empty");
             return;
         }
 

--- a/Companion/Views/SimpleMessageDialog.axaml
+++ b/Companion/Views/SimpleMessageDialog.axaml
@@ -1,0 +1,26 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="Companion.Views.SimpleMessageDialog"
+        Width="360"
+        MinWidth="220"
+        MinHeight="120"
+        CanResize="False"
+        ShowInTaskbar="False"
+        WindowStartupLocation="CenterOwner"
+        SystemDecorations="BorderOnly">
+    <Border Padding="14">
+        <Grid RowDefinitions="*,Auto" RowSpacing="10">
+            <TextBlock x:Name="MessageTextBlock"
+                       TextWrapping="Wrap"
+                       TextAlignment="Center"
+                       VerticalAlignment="Center"
+                       HorizontalAlignment="Stretch" />
+
+            <StackPanel x:Name="ButtonsPanel"
+                        Grid.Row="1"
+                        Orientation="Horizontal"
+                        HorizontalAlignment="Center"
+                        Spacing="10" />
+        </Grid>
+    </Border>
+</Window>

--- a/Companion/Views/SimpleMessageDialog.axaml.cs
+++ b/Companion/Views/SimpleMessageDialog.axaml.cs
@@ -1,0 +1,66 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using MsBox.Avalonia.Enums;
+
+namespace Companion.Views;
+
+public partial class SimpleMessageDialog : Window
+{
+    public SimpleMessageDialog()
+    {
+        InitializeComponent();
+    }
+
+    public SimpleMessageDialog(string title, string message, ButtonEnum buttons = ButtonEnum.Ok) : this()
+    {
+        Title = title;
+        MessageTextBlock.Text = message;
+        BuildButtons(buttons);
+        ConfigureLayout(buttons, message);
+    }
+
+    private void BuildButtons(ButtonEnum buttons)
+    {
+        foreach (var (caption, result) in GetButtons(buttons))
+        {
+            var button = new Button
+            {
+                Content = caption,
+                Width = 84
+            };
+            button.Click += (_, _) => Close(result);
+            ButtonsPanel.Children.Add(button);
+        }
+    }
+
+    private void ConfigureLayout(ButtonEnum buttons, string message)
+    {
+        var isSimpleOkDialog = buttons == ButtonEnum.Ok && !message.Contains('\n');
+
+        if (isSimpleOkDialog)
+        {
+            Width = 320;
+            Height = 140;
+            MinHeight = 120;
+            SizeToContent = SizeToContent.Manual;
+            return;
+        }
+
+        Width = 420;
+        Height = double.NaN;
+        MinHeight = 140;
+        SizeToContent = SizeToContent.Height;
+    }
+
+    private static (string Caption, ButtonResult Result)[] GetButtons(ButtonEnum buttons)
+    {
+        return buttons switch
+        {
+            ButtonEnum.Ok => [("OK", ButtonResult.Ok)],
+            ButtonEnum.YesNo => [("Yes", ButtonResult.Yes), ("No", ButtonResult.No)],
+            ButtonEnum.OkCancel => [("OK", ButtonResult.Ok), ("Cancel", ButtonResult.Cancel)],
+            ButtonEnum.OkAbort => [("OK", ButtonResult.Ok), ("Abort", ButtonResult.Abort)],
+            _ => [("OK", ButtonResult.Ok)]
+        };
+    }
+}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,8 @@
 <Project>
   <PropertyGroup>
-    <AvaloniaVersion>11.2.3</AvaloniaVersion>
+    <AvaloniaVersion>11.3.14</AvaloniaVersion>
+    <AvaloniaSvgSkiaVersion>11.3.0</AvaloniaSvgSkiaVersion>
+    <AvaloniaXamlInteractivityVersion>11.3.0.6</AvaloniaXamlInteractivityVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.139" PrivateAssets="all" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,6 +3,7 @@
     <AvaloniaVersion>11.3.14</AvaloniaVersion>
     <AvaloniaSvgSkiaVersion>11.3.0</AvaloniaSvgSkiaVersion>
     <AvaloniaXamlInteractivityVersion>11.3.0.6</AvaloniaXamlInteractivityVersion>
+    <SkiaSharpNativeAssetsLinuxVersion>3.116.1</SkiaSharpNativeAssetsLinuxVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.139" PrivateAssets="all" />


### PR DESCRIPTION
Summary:
- update shared Avalonia packages from 11.2.3 to 11.3.14
- align Avalonia.Svg.Skia and Avalonia.Xaml.Interactivity to the current Avalonia 11.x line
- remove the stale Avalonia.Desktop 0.10.13 test reference and use the shared Avalonia version instead

Testing:
- version normalization and repo consistency checks only
- dotnet restore Companion.Desktop/Companion.Desktop.csproj was attempted locally but blocked by a local NuGet/network issue during package lookup